### PR TITLE
Add Babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['expo-router/babel', 'react-native-reanimated/plugin'],
+  };
+};


### PR DESCRIPTION
## Summary
- add `babel.config.js` with Expo presets

## Testing
- `npx expo run:android` *(fails: needs expo installation)*

------
https://chatgpt.com/codex/tasks/task_e_68639db81ef48320b1ebdf60c653e9e8