### PR TITLE
Improve README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # Courrier-Expert
+
+Courrier-Expert is a React Native application built with **Expo Router** for generating and managing professional letters. It includes a set of screens to create letters from templates, preview them and manage user information.
+
+## Running locally
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Start the development server:
+
+   ```bash
+   npm run dev
+   # or
+   expo start
+   ```
+
+   The app can then be opened in Expo Go or a simulator.
+
+### Using React Native DevTools
+
+To enable the React Native DevTools, add the following to `app.json` under the `expo` key and rebuild:
+
+```json
+  "jsEngine": "hermes"
+```
+
+After rebuilding the native project (`npx expo prebuild && npx expo run:ios` or `npx expo run:android`), the DevTools will be available.
+
+## Major screens
+
+- **Home** – choose a letter type and view app statistics.
+- **Create Letter** – fill in recipient information and form fields; uses `DatePicker` and `CitySelector` components.
+- **Letter Preview** – view the generated letter and share, download, email or print it.
+- **History** – list of previously created letters with actions to share, download, email or delete.
+- **Profile** – manage user information such as name, company, address and avatar.
+- **Settings** – adjust app theme and view legal information.
+
+## Components
+
+- `DatePicker` – modal date selector with formatted output.
+- `CitySelector` – choose a city based on postal code with search filtering.
+


### PR DESCRIPTION
## Summary
- expand project README with usage instructions and local dev steps
- document enabling React Native DevTools

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a3bb6e54832087f1e7b006d43ee6