### PR TITLE
Disable React Native new architecture

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     "icon": "./assets/images/icon.png",
     "scheme": "courrierexpert",
     "userInterfaceStyle": "automatic",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "ios": {
       "supportsTablet": true
     },


### PR DESCRIPTION
## Summary
- disable React Native `newArchEnabled` option to prevent the app from closing immediately on startup

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a34d11488320b604acca688b771f