### PR TITLE
Use backend service for letter generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,11 @@ After rebuilding the native project (`npx expo prebuild && npx expo run:ios` or 
 - `DatePicker` – modal date selector with formatted output.
 - `CitySelector` – choose a city based on postal code with search filtering.
 
+## Letter generation API
+
+Letters are generated using a remote service hosted at
+`https://assistant-backend-yrbx.onrender.com`. The app sends the letter type,
+recipient information and form data to the endpoint `/generate-letter`. The
+server returns the letter content in a formal style with a header and
+signature. If the request fails, an error message is displayed to the user.
+

--- a/app/create-letter.tsx
+++ b/app/create-letter.tsx
@@ -6,6 +6,7 @@ import { useLetters } from '@/contexts/LetterContext';
 import { ArrowLeft, User, Mail, Phone, MapPin, Calendar, FileText, Send, Loader } from 'lucide-react-native';
 import DatePicker from '@/components/DatePicker';
 import CitySelector from '@/components/CitySelector';
+import { generateLetterOnline } from '@/services/letterApi';
 
 interface FormField {
   key: string;
@@ -128,14 +129,13 @@ export default function CreateLetterScreen() {
     setIsGenerating(true);
 
     try {
-      // Simulation d'appel API
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      const generatedContent = await generateLetterOnline(type || 'motivation', recipient, formData);
 
       const newLetter = {
         id: Date.now().toString(),
         type: type || 'motivation',
         title: `${typeLabels[type || 'motivation']} - ${recipient.firstName} ${recipient.lastName}`,
-        content: `Lettre générée pour ${recipient.firstName} ${recipient.lastName} concernant ${typeLabels[type || 'motivation']}.`,
+        content: generatedContent,
         recipient,
         data: formData,
         createdAt: new Date(),
@@ -159,6 +159,7 @@ export default function CreateLetterScreen() {
         ]
       );
     } catch (error) {
+      console.error(error);
       Alert.alert('Erreur', 'Une erreur est survenue lors de la génération du courrier');
     } finally {
       setIsGenerating(false);

--- a/app/letter-preview.tsx
+++ b/app/letter-preview.tsx
@@ -195,7 +195,7 @@ export default function LetterPreviewScreen() {
       date: currentDate,
       location: currentLocation,
       subject: letter.title,
-      content: generateContentByType(letter.type, letter.data, letter.recipient)
+      content: letter.content || generateContentByType(letter.type, letter.data, letter.recipient)
     };
   };
 

--- a/services/letterApi.ts
+++ b/services/letterApi.ts
@@ -1,0 +1,14 @@
+export async function generateLetterOnline(type: string, recipient: any, data: Record<string, any>): Promise<string> {
+  const response = await fetch('https://assistant-backend-yrbx.onrender.com/generate-letter', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ type, recipient, data })
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to generate letter');
+  }
+
+  const result = await response.json();
+  return result.content as string;
+}


### PR DESCRIPTION
## Summary
- generate letters via API instead of mock delay
- use generated content in preview if available
- document backend letter generation

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d5c7aab48320b5a7ccace6d4b9d9