### PR TITLE
Add basic legal pages

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -29,8 +29,8 @@ export default function SettingsScreen() {
     setTheme(selectedTheme);
   };
 
-  const handleLegalPage = (page: string) => {
-    Alert.alert('Page légale', `Ouverture de ${page}`);
+  const handleLegalPage = (slug: string) => {
+    router.push(`/legal/${slug}`);
   };
 
   const handleAction = (action: string) => {
@@ -127,21 +127,21 @@ export default function SettingsScreen() {
             'Mentions légales',
             'Informations sur l\'éditeur',
             Info,
-            () => handleLegalPage('Mentions légales')
+            () => handleLegalPage('mentions-legales')
           )}
           
           {renderSetting(
             'Conditions d\'utilisation',
             'Règles d\'usage de l\'application',
             FileText,
-            () => handleLegalPage('Conditions d\'utilisation')
+            () => handleLegalPage('conditions-utilisation')
           )}
           
           {renderSetting(
             'Politique RGPD',
             'Protection des données personnelles',
             Shield,
-            () => handleLegalPage('Politique RGPD')
+            () => handleLegalPage('politique-rgpd')
           )}
         </View>
 

--- a/app/legal/_layout.tsx
+++ b/app/legal/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function LegalLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/app/legal/conditions-utilisation.tsx
+++ b/app/legal/conditions-utilisation.tsx
@@ -1,0 +1,12 @@
+import LegalPage from '@/components/LegalPage';
+import React from 'react';
+
+export default function ConditionsUtilisation() {
+  return (
+    <LegalPage title="Conditions d'utilisation">
+      {`L'utilisation de l'application drcomputer60290 est réservée à un usage personnel.
+Toute reproduction ou diffusion sans autorisation est interdite.
+Les données saisies restent sur votre appareil et ne sont pas partagées.`}
+    </LegalPage>
+  );
+}

--- a/app/legal/mentions-legales.tsx
+++ b/app/legal/mentions-legales.tsx
@@ -1,0 +1,13 @@
+import LegalPage from '@/components/LegalPage';
+import React from 'react';
+
+export default function MentionsLegales() {
+  return (
+    <LegalPage title="Mentions légales">
+      {`Société : drcomputer60290
+Propriétaire : Benjamin Albert (SIREN 804 581 437)
+
+Cette application est développée à des fins de démonstration. Les informations fournies sont indicatives et peuvent être modifiées sans préavis.`}
+    </LegalPage>
+  );
+}

--- a/app/legal/politique-rgpd.tsx
+++ b/app/legal/politique-rgpd.tsx
@@ -1,0 +1,12 @@
+import LegalPage from '@/components/LegalPage';
+import React from 'react';
+
+export default function PolitiqueRGPD() {
+  return (
+    <LegalPage title="Politique RGPD">
+      {`Aucune donnée personnelle n'est collectée par drcomputer60290.
+Les informations que vous saisissez restent uniquement sur votre appareil.
+Vous pouvez supprimer vos données à tout moment en désinstallant l'application.`}
+    </LegalPage>
+  );
+}

--- a/components/LegalPage.tsx
+++ b/components/LegalPage.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { View, Text, ScrollView, StyleSheet, TouchableOpacity } from 'react-native';
+import { ArrowLeft } from 'lucide-react-native';
+import { useRouter } from 'expo-router';
+import { useTheme } from '@/contexts/ThemeContext';
+
+interface LegalPageProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+export default function LegalPage({ title, children }: LegalPageProps) {
+  const { colors } = useTheme();
+  const router = useRouter();
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={styles.header}>
+        <TouchableOpacity
+          onPress={() => router.back()}
+          style={[styles.backButton, { backgroundColor: colors.surface }]}
+        >
+          <ArrowLeft size={24} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.title, { color: colors.text }]}>{title}</Text>
+      </View>
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        <Text style={[styles.text, { color: colors.text }]}>
+          {children}
+        </Text>
+        <View style={{ height: 80 }} />
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 50,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    marginBottom: 24,
+  },
+  backButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontFamily: 'Inter-Bold',
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+  text: {
+    fontSize: 16,
+    fontFamily: 'Inter-Regular',
+    lineHeight: 24,
+  },
+});


### PR DESCRIPTION
## Summary
- implement generic `LegalPage` component
- create legal pages for mentions légales, conditions d'utilisation and RGPD
- add stack layout for legal pages
- link legal entries from Settings screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d6e074b08320b51c0959927ecd18