### PR TITLE
Add offline letter generation fallback

### DIFF
--- a/app/create-letter.tsx
+++ b/app/create-letter.tsx
@@ -6,7 +6,7 @@ import { useLetters } from '@/contexts/LetterContext';
 import { ArrowLeft, User, Mail, Phone, MapPin, Calendar, FileText, Send, Loader } from 'lucide-react-native';
 import DatePicker from '@/components/DatePicker';
 import CitySelector from '@/components/CitySelector';
-import { generateLetterOnline } from '@/services/letterApi';
+import { generateLetter } from '@/services/letterApi';
 
 interface FormField {
   key: string;
@@ -123,13 +123,13 @@ export default function CreateLetterScreen() {
     return true;
   };
 
-  const generateLetter = async () => {
+  const handleGenerateLetter = async () => {
     if (!validateForm()) return;
 
     setIsGenerating(true);
 
     try {
-      const generatedContent = await generateLetterOnline(type || 'motivation', recipient, formData);
+      const generatedContent = await generateLetter(type || 'motivation', recipient, formData);
 
       const newLetter = {
         id: Date.now().toString(),
@@ -269,7 +269,7 @@ export default function CreateLetterScreen() {
             styles.generateButton,
             { backgroundColor: isGenerating ? colors.textSecondary : colors.primary }
           ]}
-          onPress={generateLetter}
+          onPress={handleGenerateLetter}
           disabled={isGenerating}
         >
           {isGenerating ? (

--- a/services/letterApi.ts
+++ b/services/letterApi.ts
@@ -1,3 +1,5 @@
+import { generateContentByType } from '@/utils/letterPdf';
+
 export async function generateLetterOnline(type: string, recipient: any, data: Record<string, any>): Promise<string> {
   const response = await fetch('https://assistant-backend-yrbx.onrender.com/generate-letter', {
     method: 'POST',
@@ -11,4 +13,17 @@ export async function generateLetterOnline(type: string, recipient: any, data: R
 
   const result = await response.json();
   return result.content as string;
+}
+
+export function generateLetterOffline(type: string, recipient: any, data: Record<string, any>): string {
+  return generateContentByType(type, data, recipient);
+}
+
+export async function generateLetter(type: string, recipient: any, data: Record<string, any>): Promise<string> {
+  try {
+    return await generateLetterOnline(type, recipient, data);
+  } catch (error) {
+    console.warn('Online generation failed, using offline fallback', error);
+    return generateLetterOffline(type, recipient, data);
+  }
 }

--- a/utils/letterPdf.ts
+++ b/utils/letterPdf.ts
@@ -10,7 +10,7 @@ const formatDate = (date: Date) => {
   }).format(new Date(date));
 };
 
-const generateContentByType = (
+export const generateContentByType = (
   type: string,
   data: Record<string, any>,
   recipient: any,


### PR DESCRIPTION
## Summary
- export `generateContentByType`
- add `generateLetterOffline` and a fallback `generateLetter` service
- use the new service in Create Letter screen

## Testing
- `npm install`
- `npm run lint` *(fails: fetch failed)*
- `npx tsc --noEmit` *(fails with existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863ddc72a788320bda0ddf8e3f071bb