### PR TITLE
Fix letter API endpoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ After rebuilding the native project (`npx expo prebuild && npx expo run:ios` or 
 
 Letters are generated using a remote service hosted at
 `https://assistant-backend-yrbx.onrender.com`. The app sends the letter type,
-recipient information and form data to the endpoint `/generate-letter`. The
+recipient information and form data to the endpoint `/api/generate-letter`. The
 server returns the letter content in a formal style with a header and
 signature. If the request fails, an error message is displayed to the user.
 

--- a/services/letterApi.ts
+++ b/services/letterApi.ts
@@ -1,7 +1,7 @@
 import { generateContentByType } from '@/utils/letterPdf';
 
 export async function generateLetterOnline(type: string, recipient: any, data: Record<string, any>): Promise<string> {
-  const response = await fetch('https://assistant-backend-yrbx.onrender.com/generate-letter', {
+  const response = await fetch('https://assistant-backend-yrbx.onrender.com/api/generate-letter', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ type, recipient, data })


### PR DESCRIPTION
## Summary
- fix endpoint path for letter generation in README and API call

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e095ce5c832084828ea88494d13a