### PR TITLE
Fix PDF letter content

### DIFF
--- a/utils/letterPdf.ts
+++ b/utils/letterPdf.ts
@@ -56,7 +56,7 @@ export const generateLetterContent = (
     date: currentDate,
     location: currentLocation,
     subject: letter.title,
-    content: generateContentByType(letter.type, letter.data, letter.recipient),
+    content: letter.content,
   };
 };
 


### PR DESCRIPTION
## Summary
- remove content generation by letter type in `generateLetterContent`
- rely on stored `letter.content` for PDF/html output

## Testing
- `npm run lint` *(fails: fetch failed to api.expo.dev)*

------
https://chatgpt.com/codex/tasks/task_e_6863e893fa7c8320bed8171f54a8325a