### PR TITLE
Fix missing prompt in letter API requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ Letters are generated using a remote AI service hosted at `https://assistant-bac
 
 ### API Request Format
 
-The app now sends structured data instead of a pre-generated prompt:
+The backend expects a `prompt` string built from the letter information:
 
 ```typescript
 POST https://assistant-backend-yrbx.onrender.com/api/generate-letter
 Content-Type: application/json
 
 {
+  "prompt": "R\u00e9dige une lettre professionnelle de type ...",
   "type": "motivation", // Letter type
   "recipient": {
     "firstName": "Jean",

--- a/services/letterApi.ts
+++ b/services/letterApi.ts
@@ -1,19 +1,27 @@
 // services/letterApi.ts
 
+function buildPrompt(type: string, recipient: any, data: Record<string, any>): string {
+  const recipientInfo = `${recipient.status ? recipient.status + ' ' : ''}${recipient.firstName} ${recipient.lastName}`.trim();
+  const details = Object.entries(data)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(', ');
+  return `Rédige une lettre professionnelle de type "${type}" pour ${recipientInfo}. Informations supplémentaires: ${details}.`;
+}
 
 export async function generateLetter(
   type: string,
   recipient: any,
   data: Record<string, any>
 ): Promise<string> {
-  console.log('Envoi des données au serveur:', { type, recipient, data });
+  const prompt = buildPrompt(type, recipient, data);
+  console.log('Envoi des données au serveur:', { type, recipient, data, prompt });
 
   const response = await fetch(
     'https://assistant-backend-yrbx.onrender.com/api/generate-letter',
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ type, recipient, data }),
+      body: JSON.stringify({ type, recipient, data, prompt }),
     }
   );
 


### PR DESCRIPTION
## Summary
- generate a text prompt from letter data before sending API request
- include that prompt in the POST body
- document the new API requirement in README
- add `.gitignore`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails to fetch expo config due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68678375a27483208b7b5911a0b2106e