### PR TITLE
Add location and subject lines

### DIFF
--- a/app/letter-preview.tsx
+++ b/app/letter-preview.tsx
@@ -158,15 +158,16 @@ export default function LetterPreviewScreen() {
         >
           {/* Adresse expéditeur + date */}
           <View style={styles.senderDate}>
-            <Text style={[styles.senderText, { color: colors.text }]}> {content.sender} </Text>
-            <Text style={[styles.dateText, { color: colors.text }]}> {content.date} </Text>
+            <Text style={[styles.senderText, { color: colors.text }]}>{content.sender}</Text>
+            <Text style={[styles.dateText, { color: colors.text }]}> {`${content.location}, le ${content.date}`} </Text>
           </View>
 
           {/* Destinataire */}
           <View style={styles.recipientInfo}>
-            <Text style={[styles.recipientText, { color: colors.text }]}>
-              {content.recipient}
-            </Text>
+            <Text style={[styles.recipientText, { color: colors.text }]}> {content.recipient} </Text>
+          </View>
+          <View style={styles.subjectLine}>
+            <Text style={[styles.subjectText, { color: colors.text }]}>Objet : {content.subject}</Text>
           </View>
 
           {/* Référence */}
@@ -265,6 +266,8 @@ const styles = StyleSheet.create({
   dateText: { fontSize: 14, fontFamily: 'Inter-Regular' },
   recipientInfo: { marginBottom: 24 },
   recipientText: { fontSize: 14, fontFamily: 'Inter-Regular', lineHeight: 20 },
+  subjectLine: { marginBottom: 24 },
+  subjectText: { fontSize: 14, fontFamily: 'Inter-SemiBold' },
   referenceLine: { marginBottom: 24 },
   referenceText: { fontSize: 14, fontFamily: 'Inter-SemiBold', fontStyle: 'italic' },
   salutationLine: { marginBottom: 24 },

--- a/utils/letterPdf.ts
+++ b/utils/letterPdf.ts
@@ -70,6 +70,7 @@ export const generateHtml = (letter: Letter, profile: UserProfile) => {
           body { font-family: Arial, sans-serif; margin: 40px; line-height: 1.6; color: #333; }
           .sender-date { text-align: right; margin-bottom: 20px; }
           .recipient { margin-bottom: 20px; font-size: 14px; }
+          .subject { margin-bottom: 20px; font-weight: bold; }
           .reference { margin-bottom: 20px; font-size: 14px; font-style: italic; }
           .salutation { margin-bottom: 20px; }
           .body { margin-bottom: 20px; line-height: 1.8; }
@@ -80,9 +81,10 @@ export const generateHtml = (letter: Letter, profile: UserProfile) => {
       <body>
         <div class="sender-date">
           <div class="sender">${content.sender.replace(/\n/g, '<br>')}</div>
-          <div class="date">${content.date}</div>
+          <div class="date">${content.location}, le ${content.date}</div>
         </div>
         <div class="recipient">${content.recipient.replace(/\n/g, '<br>')}</div>
+        <div class="subject">Objet : ${content.subject}</div>
         ${content.reference ? `<div class="reference">Réf. : ${content.reference}</div>` : ''}
         <p class="salutation">${content.salutation}</p>
         <div class="body">${content.body.replace(/\n/g, '<br><br>')}</div>


### PR DESCRIPTION
## Summary
- show letter location next to date
- include subject line after recipient in PDF and preview
- update styling for new subject line

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6867eb6790c88320b54fe25bc52f85e7