### PR TITLE
Add user status field

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -103,6 +103,7 @@ export default function ProfileScreen() {
         <View style={[styles.section, { backgroundColor: colors.card, borderColor: colors.border }]}>
           <Text style={[styles.sectionTitle, { color: colors.text }]}>Informations personnelles</Text>
           
+          {renderField('Civilité', profile.status, 'status', User, 'Monsieur')}
           {renderField('Prénom', profile.firstName, 'firstName', User, 'Votre prénom')}
           {renderField('Nom', profile.lastName, 'lastName', User, 'Votre nom')}
           {renderField('Société', profile.company, 'company', Building, 'Nom de votre société')}

--- a/contexts/UserContext.tsx
+++ b/contexts/UserContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState } from 'react';
 
 export interface UserProfile {
+  status: string;
   firstName: string;
   lastName: string;
   company: string;
@@ -19,6 +20,7 @@ interface UserContextType {
 }
 
 const defaultProfile: UserProfile = {
+  status: '',
   firstName: '',
   lastName: '',
   company: '',

--- a/utils/letterPdf.ts
+++ b/utils/letterPdf.ts
@@ -15,7 +15,7 @@ export const generateLetterContent = (
   letter: Letter,
   profile: UserProfile,
 ) => {
-  const senderInfo = `${profile.firstName} ${profile.lastName}${profile.company ? `\n${profile.company}` : ''}${profile.address ? `\n${profile.address}` : ''}${profile.postalCode && profile.city ? `\n${profile.postalCode} ${profile.city}` : ''}${profile.email ? `\n${profile.email}` : ''}${profile.phone ? `\n${profile.phone}` : ''}`;
+  const senderInfo = `${profile.status ? profile.status + ' ' : ''}${profile.firstName} ${profile.lastName}${profile.company ? `\n${profile.company}` : ''}${profile.address ? `\n${profile.address}` : ''}${profile.postalCode && profile.city ? `\n${profile.postalCode} ${profile.city}` : ''}${profile.email ? `\n${profile.email}` : ''}${profile.phone ? `\n${profile.phone}` : ''}`;
 
   const recipientInfo = `${letter.recipient.status ? letter.recipient.status + ' ' : ''}${letter.recipient.firstName} ${letter.recipient.lastName}${letter.recipient.address ? `\n${letter.recipient.address}` : ''}${letter.recipient.postalCode && letter.recipient.city ? `\n${letter.recipient.postalCode} ${letter.recipient.city}` : ''}`;
 


### PR DESCRIPTION
## Summary
- extend `UserProfile` with new `status` property
- update defaultProfile and provider
- allow editing status on profile screen
- include sender's status in generated letters

## Testing
- `npm run lint` *(fails: fetch failed)*
- `npx tsc --noEmit` *(fails: TS2322 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867eb6988e083208f00898edd103c45