### PR TITLE
Use profile when creating letter PDFs

### DIFF
--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Alert, Platform } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useLetters } from '@/contexts/LetterContext';
+import { useUser } from '@/contexts/UserContext';
 import { useRouter } from 'expo-router';
 import { FileText, Share2, Download, Mail, Trash2, Calendar } from 'lucide-react-native';
 import * as Sharing from 'expo-sharing';
@@ -11,6 +12,7 @@ import { generatePdf } from '@/utils/letterPdf';
 export default function HistoryScreen() {
   const { colors } = useTheme();
   const { letters, deleteLetter } = useLetters();
+  const { profile } = useUser();
   const router = useRouter();
 
   const handleLetterPress = (letterId: string) => {
@@ -22,7 +24,7 @@ export default function HistoryScreen() {
 
   const handleShare = async (letter: any) => {
     try {
-      const pdfUri = await generatePdf(letter);
+      const pdfUri = await generatePdf(letter, profile);
       if (Platform.OS === 'web') {
         if (navigator.share) {
           await navigator.share({ title: letter.title, url: pdfUri });
@@ -44,7 +46,7 @@ export default function HistoryScreen() {
 
   const handleDownload = async (letter: any) => {
     try {
-      const pdfUri = await generatePdf(letter);
+      const pdfUri = await generatePdf(letter, profile);
       if (Platform.OS === 'web') {
         const link = document.createElement('a');
         link.href = pdfUri;
@@ -65,7 +67,7 @@ export default function HistoryScreen() {
       const isAvailable = await MailComposer.isAvailableAsync();
 
       if (isAvailable) {
-        const pdfUri = await generatePdf(letter);
+        const pdfUri = await generatePdf(letter, profile);
         await MailComposer.composeAsync({
           recipients: [letter.recipient.email].filter(Boolean),
           subject: letter.title,

--- a/utils/letterPdf.ts
+++ b/utils/letterPdf.ts
@@ -95,7 +95,8 @@ export const generateHtml = (letter: Letter, profile: UserProfile) => {
   `;
 };
 
-export const generatePdf = async (letter: Letter) => {
-  const { uri } = await Print.printToFileAsync({ html: letter.content });
+export const generatePdf = async (letter: Letter, profile: UserProfile) => {
+  const html = generateHtml(letter, profile);
+  const { uri } = await Print.printToFileAsync({ html });
   return uri;
 };


### PR DESCRIPTION
## Summary
- include `useUser` in letter preview to load the profile
- build preview HTML via `generateHtml(letter, profile)`
- update `generatePdf` to accept a profile
- pass the profile whenever generating PDFs

## Testing
- `npm run lint` *(fails: fetch failed)*
- `npm test` *(fails: missing script)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68690216c7788320a67715b592b95ede