### PR TITLE
Add subject/body parameters and updated prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,13 @@ After rebuilding the native project (`npx expo prebuild && npx expo run:ios` or 
 
 ## Letter generation API
 
-Letters are generated using a remote AI service whose base URL is defined by the `BACKEND_URL` environment variable. The app sends **raw form data** to the endpoint `/api/generate-letter`. The server uses ChatGPT to generate professional, personalized letter content based on the letter type, recipient information, and form data.
+Letters are generated using a remote AI service whose base URL is defined by the `BACKEND_URL` environment variable. The API prompt now starts with:
+
+```
+Tu es un assistant qui rédige des lettres officielles au format administratif français
+```
+
+The app sends structured data to `/api/generate-letter` which the server turns into a detailed prompt including the letter type, recipient, subject, body and sender profile.
 
 ### API Requirements
 
@@ -64,7 +70,9 @@ Letters are generated using a remote AI service whose base URL is defined by the
 
 ### API Request Format
 
-The app now sends structured data instead of a pre-generated prompt:
+The app now sends structured data instead of a pre-generated prompt. The backend
+expects the sender profile, an optional subject and body, plus any additional
+form data:
 
 ```typescript
 POST $BACKEND_URL/api/generate-letter
@@ -72,6 +80,8 @@ Content-Type: application/json
 
 {
   "type": "motivation", // Letter type
+  "subject": "Objet du courrier",
+  "body": "Texte libre saisi par l'utilisateur",
   "recipient": {
     "firstName": "Jean",
     "lastName": "Dupont",
@@ -81,6 +91,15 @@ Content-Type: application/json
     "city": "Paris",
     "email": "jean.dupont@email.com",
     "phone": "01 23 45 67 89"
+  },
+  "profile": {
+    "firstName": "Alice",
+    "lastName": "Martin",
+    "address": "5 rue des Lilas",
+    "postalCode": "75002",
+    "city": "Paris",
+    "phone": "01 02 03 04 05",
+    "email": "alice@example.com"
   },
   "data": {
     "position": "Développeur Full-Stack",

--- a/app/create-letter.tsx
+++ b/app/create-letter.tsx
@@ -141,7 +141,14 @@ export default function CreateLetterScreen() {
     setGenerationError(null);
 
     try {
-      const generatedContent = await generateLetter(type || 'motivation', recipient, profile, formData);
+      const generatedContent = await generateLetter(
+        type || 'motivation',
+        recipient,
+        profile,
+        formData.subject || '',
+        formData.body || '',
+        formData
+      );
 
       const newLetter = {
         id: Date.now().toString(),

--- a/services/letterApi.ts
+++ b/services/letterApi.ts
@@ -15,28 +15,40 @@ function buildPrompt(
   type: string,
   recipient: any,
   profile: UserProfile,
+  subject: string,
+  body: string,
   data: Record<string, any>
 ): string {
   const recipientInfo = `${
     recipient.status ? recipient.status + ' ' : ''
   }${recipient.firstName} ${recipient.lastName}`.trim();
-  const senderInfo = `${
-    profile.firstName
-  } ${profile.lastName}${profile.company ? `, ${profile.company}` : ''}`.trim();
+
+  const senderInfo = `${profile.firstName} ${profile.lastName}`.trim();
+
+  const address = `${profile.address}, ${profile.postalCode} ${profile.city}`.trim();
+
+  const contact = `Téléphone: ${profile.phone}, Email: ${profile.email}`;
+
   const details = Object.entries(data)
     .map(([key, value]) => `${key}: ${value}`)
     .join(', ');
-  return `Rédige une lettre professionnelle de type "${type}". Expéditeur: ${senderInfo}. Destinataire: ${recipientInfo}. Informations supplémentaires: ${details}.`;
+
+  return `Tu es un assistant qui rédige des lettres officielles au format administratif français. ` +
+    `Type: ${type}. Objet: ${subject}. Corps: ${body}. ` +
+    `Expéditeur: ${senderInfo}, ${address}. ${contact}. ` +
+    `Destinataire: ${recipientInfo}. Informations supplémentaires: ${details}.`;
 }
 
 export async function generateLetter(
   type: string,
   recipient: any,
   profile: UserProfile,
+  subject: string,
+  body: string,
   data: Record<string, any>
 ): Promise<string> {
-  const prompt = buildPrompt(type, recipient, profile, data);
-  console.log('Envoi des données au serveur:', { type, recipient, profile, data, prompt });
+  const prompt = buildPrompt(type, recipient, profile, subject, body, data);
+  console.log('Envoi des données au serveur:', { type, recipient, profile, subject, body, data, prompt });
 
   const maxRetries = 3;
   let attempt = 0;
@@ -48,7 +60,7 @@ export async function generateLetter(
     response = await fetch(API_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ type, recipient, profile, data, prompt }),
+      body: JSON.stringify({ type, recipient, profile, subject, body, data, prompt }),
     });
 
     console.log('Réponse du serveur:', response.status, response.statusText);


### PR DESCRIPTION
## Summary
- improve prompt generator to use a French administrative style
- send subject and body to the letter API
- adjust create-letter screen for new `generateLetter` signature
- document new API payload fields

## Testing
- `npx tsc --noEmit services/letterApi.ts` *(fails: conflicting TS definitions)*
- `npm run lint` *(fails to fetch expo config)*

------
https://chatgpt.com/codex/tasks/task_e_6873e6d182b8832083f508d7fff71435