### PR TITLE
Fix letter prompt to place sender info at top

### DIFF
--- a/services/letterApi.ts
+++ b/services/letterApi.ts
@@ -33,10 +33,13 @@ function buildPrompt(
     .map(([key, value]) => `${key}: ${value}`)
     .join(', ');
 
-  return `Tu es un assistant qui rédige des lettres officielles au format administratif français. ` +
+  return (
+    'Tu es un assistant qui rédige des lettres officielles au format administratif français. ' +
+    "Les coordonnées de l'expéditeur doivent être placées en haut du courrier avant celles du destinataire. " +
     `Type: ${type}. Objet: ${subject}. Corps: ${body}. ` +
     `Expéditeur: ${senderInfo}, ${address}. ${contact}. ` +
-    `Destinataire: ${recipientInfo}. Informations supplémentaires: ${details}.`;
+    `Destinataire: ${recipientInfo}. Informations supplémentaires: ${details}.`
+  );
 }
 
 export async function generateLetter(


### PR DESCRIPTION
## Summary
- tweak letter API prompt to instruct placing sender info at the beginning

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6873ee10b3d483209416919319a68b86