### PR TITLE
Fix newline parsing

### DIFF
--- a/services/letterApi.ts
+++ b/services/letterApi.ts
@@ -102,5 +102,7 @@ export async function generateLetter(
     throw new Error('Réponse invalide du serveur: contenu manquant');
   }
 
-  return result.content as string;
+  const raw = result.content as string;
+  const content = raw.replace(/\\n/g, '\n');
+  return content;
 }


### PR DESCRIPTION
## Summary
- ensure letter content newline characters are unescaped

## Testing
- `npm run lint` *(fails: fetch failed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6873ef35daa88320b88c26a1396462c8