### PR TITLE
Add .env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment configuration
+BACKEND_URL=https://assistant-backend-yrbx.onrender.com

--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ Courrier-Expert is a React Native application built with **Expo Router** for gen
 
    The app can then be opened in Expo Go or a simulator.
 
-3. Create an `.env` file at the project root and define the backend URL used during development:
+3. Copy `.env.example` to `.env` and update the backend URL for your environment:
 
    ```bash
-   BACKEND_URL=https://assistant-backend-yrbx.onrender.com
+   cp .env.example .env
+   # then edit BACKEND_URL inside .env if needed
    ```
 
    For production builds, set `BACKEND_URL` to the appropriate server URL in your deployment environment.


### PR DESCRIPTION
## Summary
- add `.env.example` with `BACKEND_URL`
- mention copying this template in `README.md`

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6873ef3716e08320b516f09410850096