### PR TITLE
Add typed Recipient interface

### DIFF
--- a/app/create-letter.tsx
+++ b/app/create-letter.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TextInput, TouchableOpacity, Alert } from 'react-native';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useTheme } from '@/contexts/ThemeContext';
-import { useLetters } from '@/contexts/LetterContext';
+import { useLetters, Recipient } from '@/contexts/LetterContext';
 import { useUser } from '@/contexts/UserContext';
 import { ArrowLeft, User, Mail, Phone, MapPin, Calendar, FileText, Send, Loader, Wifi, WifiOff } from 'lucide-react-native';
 import DatePicker from '@/components/DatePicker';
@@ -75,7 +75,7 @@ export default function CreateLetterScreen() {
   const router = useRouter();
 
   const [formData, setFormData] = useState<Record<string, string>>({});
-  const [recipient, setRecipient] = useState({
+  const [recipient, setRecipient] = useState<Recipient>({
     firstName: '',
     lastName: '',
     status: '',
@@ -108,7 +108,7 @@ export default function CreateLetterScreen() {
     }
   };
 
-  const handleRecipientChange = (key: string, value: string) => {
+  const handleRecipientChange = (key: keyof Recipient, value: string) => {
     setRecipient(prev => ({ ...prev, [key]: value }));
     // Clear error when user starts typing
     if (generationError) {
@@ -235,7 +235,7 @@ export default function CreateLetterScreen() {
     );
   };
 
-  const renderRecipientField = (key: string, label: string, placeholder: string, icon: React.ComponentType<any>) => (
+  const renderRecipientField = (key: keyof Recipient, label: string, placeholder: string, icon: React.ComponentType<any>) => (
     <View style={styles.fieldContainer}>
       <View style={styles.fieldHeader}>
         {React.createElement(icon, { size: 16, color: colors.textSecondary })}
@@ -243,7 +243,7 @@ export default function CreateLetterScreen() {
       </View>
       <TextInput
         style={[styles.fieldInput, { color: colors.text, borderColor: colors.border }]}
-        value={recipient[key as keyof typeof recipient]}
+        value={recipient[key]}
         onChangeText={(value) => handleRecipientChange(key, value)}
         placeholder={placeholder}
         placeholderTextColor={colors.textSecondary}

--- a/contexts/LetterContext.tsx
+++ b/contexts/LetterContext.tsx
@@ -1,20 +1,22 @@
 import React, { createContext, useContext, useState } from 'react';
 
+export interface Recipient {
+  firstName: string;
+  lastName: string;
+  status: string;
+  address: string;
+  postalCode: string;
+  city: string;
+  email: string;
+  phone: string;
+}
+
 export interface Letter {
   id: string;
   type: string;
   title: string;
   content: string;
-  recipient: {
-    firstName: string;
-    lastName: string;
-    status: string;
-    address: string;
-    postalCode: string;
-    city: string;
-    email: string;
-    phone: string;
-  };
+  recipient: Recipient;
   data: Record<string, any>;
   createdAt: Date;
 }

--- a/services/letterApi.ts
+++ b/services/letterApi.ts
@@ -2,6 +2,7 @@
 
 import { Alert } from 'react-native';
 import { UserProfile } from '@/contexts/UserContext';
+import { Recipient } from '@/contexts/LetterContext';
 import { BACKEND_URL } from '@/config';
 
 const API_URL = `${BACKEND_URL}/api/generate-letter`;
@@ -13,7 +14,7 @@ function wait(ms: number) {
 
 function buildPrompt(
   type: string,
-  recipient: any,
+  recipient: Recipient,
   profile: UserProfile,
   subject: string,
   body: string,
@@ -41,7 +42,7 @@ function buildPrompt(
 
 export async function generateLetter(
   type: string,
-  recipient: any,
+  recipient: Recipient,
   profile: UserProfile,
   subject: string,
   body: string,


### PR DESCRIPTION
## Summary
- create `Recipient` interface in `LetterContext`
- update `Letter` to use new `Recipient` type
- use `Recipient` in letter generation API and letter form screen

## Testing
- `npm run lint` *(fails: fetch to api.expo.dev blocked)*
- `npx tsc --noEmit` *(fails: type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6873ef30f5248320bbd7057494b19348