### PR TITLE
Fix newline rendering in preview

### DIFF
--- a/app/letter-preview.tsx
+++ b/app/letter-preview.tsx
@@ -150,7 +150,11 @@ export default function LetterPreviewScreen() {
             { backgroundColor: colors.card, borderColor: colors.border },
           ]}
         >
-          <Text style={[styles.bodyText, { color: colors.text }]}>\n{letter.content}\n</Text>
+          <Text style={[styles.bodyText, { color: colors.text }]}>
+            {'\n'}
+            {letter.content}
+            {'\n'}
+          </Text>
         </View>
       </ScrollView>
 


### PR DESCRIPTION
## Summary
- fix newline rendering in letter preview

## Testing
- `npm run lint` *(fails: fetch to api.expo.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6873f1d2aac08320be7172f780bfd1a6