### PR TITLE
Add date parameter for letter generation

### DIFF
--- a/app/create-letter.tsx
+++ b/app/create-letter.tsx
@@ -140,6 +140,8 @@ export default function CreateLetterScreen() {
     setIsGenerating(true);
     setGenerationError(null);
 
+    const currentDate = new Date().toLocaleDateString('fr-FR');
+
     try {
       const generatedContent = await generateLetter(
         type || 'motivation',
@@ -147,7 +149,8 @@ export default function CreateLetterScreen() {
         profile,
         formData.subject || '',
         formData.body || '',
-        formData
+        formData,
+        currentDate
       );
 
       const newLetter = {

--- a/app/letter-preview.tsx
+++ b/app/letter-preview.tsx
@@ -30,6 +30,10 @@ export default function LetterPreviewScreen() {
   // 2. Cherche la lettre dans le contexte
   const letter = letters.find(l => l.id === letterId);
 
+  const formattedDate = letter
+    ? new Date(letter.createdAt).toLocaleDateString('fr-FR')
+    : '';
+
   if (!letter) {
     return (
       <View style={[styles.container, { backgroundColor: colors.background }]}>
@@ -150,6 +154,9 @@ export default function LetterPreviewScreen() {
             { backgroundColor: colors.card, borderColor: colors.border },
           ]}
         >
+          <Text style={[styles.dateText, { color: colors.text, marginBottom: 16 }]}>
+            {profile.city}, le {formattedDate}
+          </Text>
           <Text style={[styles.bodyText, { color: colors.text }]}>\n{letter.content}\n</Text>
         </View>
       </ScrollView>

--- a/services/letterApi.ts
+++ b/services/letterApi.ts
@@ -18,7 +18,8 @@ function buildPrompt(
   profile: UserProfile,
   subject: string,
   body: string,
-  data: Record<string, any>
+  data: Record<string, any>,
+  currentDate: string
 ): string {
   const recipientInfo = `${
     recipient.status ? recipient.status + ' ' : ''
@@ -34,9 +35,12 @@ function buildPrompt(
     .map(([key, value]) => `${key}: ${value}`)
     .join(', ');
 
+  const headerLine = `${profile.city}, le ${currentDate}`;
+
   return (
     'Tu es un assistant qui rédige des lettres officielles au format administratif français. ' +
     "Les coordonnées de l'expéditeur doivent être placées en haut du courrier avant celles du destinataire. " +
+    `Le contenu de la lettre doit commencer par "${headerLine}". ` +
     `Type: ${type}. Objet: ${subject}. Corps: ${body}. ` +
     `Expéditeur: ${senderInfo}, ${address}. ${contact}. ` +
     `Destinataire: ${recipientInfo}. Informations supplémentaires: ${details}.`
@@ -49,10 +53,20 @@ export async function generateLetter(
   profile: UserProfile,
   subject: string,
   body: string,
-  data: Record<string, any>
+  data: Record<string, any>,
+  currentDate: string
 ): Promise<string> {
-  const prompt = buildPrompt(type, recipient, profile, subject, body, data);
-  console.log('Envoi des données au serveur:', { type, recipient, profile, subject, body, data, prompt });
+  const prompt = buildPrompt(type, recipient, profile, subject, body, data, currentDate);
+  console.log('Envoi des données au serveur:', {
+    type,
+    recipient,
+    profile,
+    subject,
+    body,
+    data,
+    currentDate,
+    prompt,
+  });
 
   const maxRetries = 3;
   let attempt = 0;
@@ -64,7 +78,7 @@ export async function generateLetter(
     response = await fetch(API_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ type, recipient, profile, subject, body, data, prompt }),
+      body: JSON.stringify({ type, recipient, profile, subject, body, data, prompt, currentDate }),
     });
 
     console.log('Réponse du serveur:', response.status, response.statusText);


### PR DESCRIPTION
## Summary
- accept a `currentDate` parameter in `letterApi.buildPrompt`
- use the new date when generating a letter in `create-letter`
- show the date and city in the letter preview

## Testing
- `npx tsc --noEmit` *(fails: several TS errors)*
- `npm run lint` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6873f2d8dc708320a3081e3e87a25b14