### PR TITLE
Add last recipient autofill

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ After rebuilding the native project (`npx expo prebuild && npx expo run:ios` or 
 ## Major screens
 
 * **Home** – choose a letter type and view app statistics.
-* **Create Letter** – fill in recipient information and form fields; uses `DatePicker` and `CitySelector` components.
+* **Create Letter** – fill in recipient information and form fields; uses `DatePicker` and `CitySelector` components. The last recipient entered is reused automatically for convenience.
 * **Letter Preview** – view the generated letter and share, download, email or print it.
 * **History** – list of previously created letters with actions to share, download, email or delete.
 * **Profile** – manage user information such as name, company, address and avatar.

--- a/app/create-letter.tsx
+++ b/app/create-letter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, ScrollView, TextInput, TouchableOpacity, Alert } from 'react-native';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -8,6 +8,7 @@ import { ArrowLeft, User, Mail, Phone, MapPin, Calendar, FileText, Send, Loader,
 import DatePicker from '@/components/DatePicker';
 import CitySelector from '@/components/CitySelector';
 import { generateLetter } from '@/services/letterApi';
+import { loadLastRecipient, saveLastRecipient } from '@/utils/recipientStorage';
 
 interface FormField {
   key: string;
@@ -88,6 +89,14 @@ export default function CreateLetterScreen() {
   const [isGenerating, setIsGenerating] = useState(false);
   const [generationError, setGenerationError] = useState<string | null>(null);
 
+  useEffect(() => {
+    loadLastRecipient().then(saved => {
+      if (saved) {
+        setRecipient(saved);
+      }
+    });
+  }, []);
+
   const fields = letterTypeFields[type || 'motivation'] || [];
   const typeLabels: Record<string, string> = {
     motivation: 'Lettre de motivation',
@@ -161,6 +170,7 @@ export default function CreateLetterScreen() {
       };
 
       addLetter(newLetter);
+      saveLastRecipient(recipient);
 
       Alert.alert(
         'Succès',

--- a/utils/recipientStorage.ts
+++ b/utils/recipientStorage.ts
@@ -1,0 +1,24 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Recipient } from '@/contexts/LetterContext';
+
+const STORAGE_KEY = 'lastRecipient';
+
+export async function saveLastRecipient(recipient: Recipient) {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(recipient));
+  } catch (err) {
+    console.error('Failed to save recipient', err);
+  }
+}
+
+export async function loadLastRecipient(): Promise<Recipient | null> {
+  try {
+    const json = await AsyncStorage.getItem(STORAGE_KEY);
+    if (json) {
+      return JSON.parse(json) as Recipient;
+    }
+  } catch (err) {
+    console.error('Failed to load recipient', err);
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- store last recipient in AsyncStorage
- prefill create letter screen with saved recipient
- mention autofill in README

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6873f22ee7f08320ba2acdc7f54d8b8b