### PR TITLE
Fix AdMob banner visibility on home screen

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -126,11 +126,11 @@ export default function HomeScreen() {
         {letterTypes.map(renderLetterType)}
       </View>
 
-      {/* Espace pour scroll */}
-      <View style={{ height: 80 }} />
-
       {/* Bannière AdMob */}
       <MyBanner />
+
+      {/* Espace pour scroll */}
+      <View style={{ height: 80 }} />
     </ScrollView>
   );
 }


### PR DESCRIPTION
## Summary
- display banner before spacer to avoid bottom tab overlay

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687761c38bac8320a7f5bb3e0a778d79