### PR TITLE
feat: add additional letter types

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -26,6 +26,13 @@ import {
   Users,
   FileCheck,
   User,
+  House,
+  CircleX,
+  TriangleAlert,
+  Hourglass,
+  CalendarClock,
+  Info,
+  Gavel,
 } from 'lucide-react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import MyBanner from '@/components/MyBanner';
@@ -39,6 +46,13 @@ const letterTypes = [
   { id: 'remerciement', title: 'Remerciement',       description: 'Relation client',     icon: Heart,      color: '#ec4899' },
   { id: 'administrative', title: 'Administrative',   description: 'Démarche officielle', icon: Building,   color: '#64748b' },
   { id: 'attestation', title: 'Attestation',         description: 'Document officiel',   icon: FileCheck,  color: '#06b6d4' },
+  { id: 'preavis',      title: 'Préavis de départ',  description: 'Quitter un logement', icon: House,      color: '#0ea5e9' },
+  { id: 'resiliation',  title: 'Résiliation',        description: 'Fin d\'abonnement',   icon: CircleX,   color: '#dc2626' },
+  { id: 'contestation', title: 'Contestation',       description: 'Contester une décision', icon: TriangleAlert, color: '#f97316' },
+  { id: 'delai-paiement', title: 'Délai de paiement', description: 'Demande de report', icon: Hourglass, color: '#eab308' },
+  { id: 'entretien',    title: "Demande d'entretien", description: 'Fixer un rendez-vous', icon: CalendarClock, color: '#16a34a' },
+  { id: 'information',  title: 'Lettre d\'information', description: 'Communiquer une nouvelle', icon: Info, color: '#0284c7' },
+  { id: 'mise-en-demeure', title: 'Mise en demeure', description: 'Ultimatum juridique', icon: Gavel, color: '#7f1d1d' },
 ];
 
 export default function HomeScreen() {

--- a/app/create-letter.tsx
+++ b/app/create-letter.tsx
@@ -66,6 +66,49 @@ const letterTypeFields: Record<string, FormField[]> = {
     { key: 'period', label: 'Période concernée', type: 'text', placeholder: '01/01/2024 - 31/12/2024' },
     { key: 'additional', label: 'Informations supplémentaires', type: 'multiline', placeholder: 'Détails additionnels...' },
   ],
+  preavis: [
+    { key: 'propertyAddress', label: 'Adresse du logement', type: 'text', placeholder: 'Adresse complète', required: true },
+    { key: 'leaseStart', label: 'Date de début de bail', type: 'date', placeholder: 'JJ/MM/AAAA', required: true },
+    { key: 'departureDate', label: 'Date de départ souhaitée', type: 'date', placeholder: 'JJ/MM/AAAA', required: true },
+    { key: 'noticePeriod', label: 'Durée du préavis', type: 'text', placeholder: '3 mois', required: true },
+  ],
+  resiliation: [
+    { key: 'service', label: 'Fournisseur / Service', type: 'text', placeholder: 'Nom du service', required: true },
+    { key: 'contractNumber', label: 'Numéro de contrat', type: 'text', placeholder: 'CTR-2024-001', required: true },
+    { key: 'terminationDate', label: 'Date souhaitée de résiliation', type: 'date', placeholder: 'JJ/MM/AAAA', required: true },
+    { key: 'reason', label: 'Motif', type: 'multiline', placeholder: 'Raison de la résiliation' },
+  ],
+  contestation: [
+    { key: 'reference', label: 'Référence contestée', type: 'text', placeholder: 'Facture, PV...', required: true },
+    { key: 'reason', label: 'Motif de contestation', type: 'multiline', placeholder: 'Expliquez le motif', required: true },
+    { key: 'incidentDate', label: "Date de l'incident", type: 'date', placeholder: 'JJ/MM/AAAA', required: true },
+    { key: 'incidentPlace', label: "Lieu de l'incident", type: 'text', placeholder: 'Ville ou adresse', required: true },
+    { key: 'evidence', label: 'Pièces justificatives', type: 'multiline', placeholder: 'Références ou description' },
+  ],
+  'delai-paiement': [
+    { key: 'invoiceNumber', label: 'Numéro de facture', type: 'text', placeholder: 'FAC-2024-001', required: true },
+    { key: 'amount', label: 'Montant dû (€)', type: 'number', placeholder: '1500', required: true },
+    { key: 'currentDueDate', label: "Date d'échéance actuelle", type: 'date', placeholder: 'JJ/MM/AAAA', required: true },
+    { key: 'desiredDueDate', label: "Date d'échéance souhaitée", type: 'date', placeholder: 'JJ/MM/AAAA', required: true },
+    { key: 'justification', label: 'Justification', type: 'multiline', placeholder: 'Expliquez votre demande', required: true },
+  ],
+  entretien: [
+    { key: 'subject', label: "Objet de l'entretien", type: 'text', placeholder: 'Motif du rendez-vous', required: true },
+    { key: 'desiredDate', label: 'Date souhaitée', type: 'date', placeholder: 'JJ/MM/AAAA', required: true },
+    { key: 'desiredTime', label: 'Heure souhaitée', type: 'text', placeholder: '14:00', required: true },
+    { key: 'context', label: 'Contexte / motif', type: 'multiline', placeholder: 'Détails supplémentaires' },
+  ],
+  information: [
+    { key: 'topic', label: "Sujet de l'information", type: 'text', placeholder: 'Objet', required: true },
+    { key: 'details', label: 'Détails / message', type: 'multiline', placeholder: 'Votre message...', required: true },
+    { key: 'effectiveDate', label: "Date d'effet", type: 'date', placeholder: 'JJ/MM/AAAA' },
+  ],
+  'mise-en-demeure': [
+    { key: 'subject', label: 'Objet du litige', type: 'text', placeholder: 'Conflit', required: true },
+    { key: 'amount', label: 'Montant ou obligation', type: 'text', placeholder: 'Montant dû ou obligation', required: true },
+    { key: 'contractRef', label: 'Référence de contrat / dossier', type: 'text', placeholder: 'REF-2024-001', required: true },
+    { key: 'deadline', label: 'Délai avant action', type: 'text', placeholder: '15 jours', required: true },
+  ],
 };
 
 export default function CreateLetterScreen() {
@@ -107,6 +150,13 @@ export default function CreateLetterScreen() {
     remerciement: 'Lettre de remerciement',
     administrative: 'Courrier administratif',
     attestation: 'Demande d\'attestation',
+    preavis: 'Préavis de départ',
+    resiliation: "Résiliation d'abonnement",
+    contestation: 'Lettre de contestation',
+    'delai-paiement': 'Demande de délai de paiement',
+    entretien: "Demande d'entretien",
+    information: "Lettre d'information",
+    'mise-en-demeure': 'Mise en demeure',
   };
 
   const handleInputChange = (key: string, value: string) => {


### PR DESCRIPTION
## Summary
- expand form configuration and labels for preavis, resiliation, contestation, delay requests, meeting requests, informational letters, and mises en demeure
- display new letter type cards on home screen with icons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: fetch failed)*
- `npx tsc --noEmit` *(fails: Type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7cc3ee58832099e5cd5ff2d13a3f