### PR TITLE
feat: persist letters history

### DIFF
--- a/contexts/LetterContext.tsx
+++ b/contexts/LetterContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { loadLetters, saveLetters } from '@/utils/letterStorage';
 
 export interface Recipient {
   firstName: string;
@@ -39,18 +40,34 @@ const LetterContext = createContext<LetterContextType | undefined>(undefined);
 export function LetterProvider({ children }: { children: React.ReactNode }) {
   const [letters, setLetters] = useState<Letter[]>([]);
 
+  useEffect(() => {
+    loadLetters().then(setLetters);
+  }, []);
+
   const addLetter = (letter: Letter) => {
-    setLetters(prev => [letter, ...prev]);
+    setLetters(prev => {
+      const updated = [letter, ...prev];
+      saveLetters(updated);
+      return updated;
+    });
   };
 
   const updateLetter = (id: string, updatedLetter: Letter) => {
-    setLetters(prev => prev.map(letter => 
-      letter.id === id ? updatedLetter : letter
-    ));
+    setLetters(prev => {
+      const updated = prev.map(letter =>
+        letter.id === id ? updatedLetter : letter
+      );
+      saveLetters(updated);
+      return updated;
+    });
   };
 
   const deleteLetter = (id: string) => {
-    setLetters(prev => prev.filter(letter => letter.id !== id));
+    setLetters(prev => {
+      const updated = prev.filter(letter => letter.id !== id);
+      saveLetters(updated);
+      return updated;
+    });
   };
 
   const getStatistics = () => {

--- a/utils/letterStorage.ts
+++ b/utils/letterStorage.ts
@@ -1,0 +1,28 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Letter } from '@/contexts/LetterContext';
+
+const STORAGE_KEY = 'letters';
+
+export async function saveLetters(letters: Letter[]) {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(letters));
+  } catch (err) {
+    console.error('Failed to save letters', err);
+  }
+}
+
+export async function loadLetters(): Promise<Letter[]> {
+  try {
+    const json = await AsyncStorage.getItem(STORAGE_KEY);
+    if (json) {
+      const parsed = JSON.parse(json) as Letter[];
+      return parsed.map(letter => ({
+        ...letter,
+        createdAt: new Date(letter.createdAt),
+      }));
+    }
+  } catch (err) {
+    console.error('Failed to load letters', err);
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary
- store letters in AsyncStorage
- load letters on context mount and persist on add/update/delete

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: TypeError: fetch failed during expo lint)*
- `npx ts-node --transpile-only --compiler-options '{"module":"commonjs","moduleResolution":"node"}' /tmp/persist1.ts` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8c28462083209202991ddd6924f1