### PR TITLE
Validate contact details in letter creation and profile

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -15,7 +15,34 @@ export default function ProfileScreen() {
   const [editedProfile, setEditedProfile] = useState(profile);
   const [showSignaturePad, setShowSignaturePad] = useState(false);
 
+  const validateProfile = () => {
+    if (!editedProfile.firstName) {
+      Alert.alert('Erreur', 'Le prénom est obligatoire');
+      return false;
+    }
+    if (!editedProfile.lastName) {
+      Alert.alert('Erreur', 'Le nom est obligatoire');
+      return false;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (editedProfile.email && !emailRegex.test(editedProfile.email)) {
+      Alert.alert('Erreur', "Veuillez entrer une adresse email valide (ex: nom@exemple.com)");
+      return false;
+    }
+
+    const phoneDigits = editedProfile.phone.replace(/\s/g, '');
+    const phoneRegex = /^\+?\d{10,15}$/;
+    if (editedProfile.phone && !phoneRegex.test(phoneDigits)) {
+      Alert.alert('Erreur', 'Veuillez entrer un numéro de téléphone valide (10 à 15 chiffres)');
+      return false;
+    }
+
+    return true;
+  };
+
   const handleSave = () => {
+    if (!validateProfile()) return;
     updateProfile(editedProfile);
     setIsEditing(false);
     Alert.alert('Succès', 'Profil mis à jour avec succès');

--- a/app/create-letter.tsx
+++ b/app/create-letter.tsx
@@ -190,6 +190,27 @@ export default function CreateLetterScreen() {
       return false;
     }
 
+    // Validation de l'email du destinataire
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!recipient.email || !emailRegex.test(recipient.email)) {
+      Alert.alert(
+        'Erreur',
+        "Veuillez entrer une adresse email valide (ex: nom@exemple.com)"
+      );
+      return false;
+    }
+
+    // Validation du téléphone du destinataire
+    const phoneDigits = recipient.phone.replace(/\s/g, '');
+    const phoneRegex = /^\+?\d{10,15}$/;
+    if (!recipient.phone || !phoneRegex.test(phoneDigits)) {
+      Alert.alert(
+        'Erreur',
+        'Veuillez entrer un numéro de téléphone valide (10 à 15 chiffres)'
+      );
+      return false;
+    }
+
     return true;
   };
 


### PR DESCRIPTION
## Summary
- enforce email and phone validation when generating letters
- check and alert profile fields before saving

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8c3230348320adb2e7188b5cafc1