### PR TITLE
feat: persist letter drafts during creation

### DIFF
--- a/utils/draftStorage.ts
+++ b/utils/draftStorage.ts
@@ -1,0 +1,38 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Recipient } from '@/contexts/LetterContext';
+
+const STORAGE_KEY = 'letterDraft';
+
+export interface LetterDraft {
+  formData: Record<string, string>;
+  recipient: Recipient;
+}
+
+export async function saveDraft(formData: Record<string, string>, recipient: Recipient) {
+  try {
+    const draft: LetterDraft = { formData, recipient };
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(draft));
+  } catch (err) {
+    console.error('Failed to save draft', err);
+  }
+}
+
+export async function loadDraft(): Promise<LetterDraft | null> {
+  try {
+    const json = await AsyncStorage.getItem(STORAGE_KEY);
+    if (json) {
+      return JSON.parse(json) as LetterDraft;
+    }
+  } catch (err) {
+    console.error('Failed to load draft', err);
+  }
+  return null;
+}
+
+export async function clearDraft() {
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch (err) {
+    console.error('Failed to clear draft', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add AsyncStorage helpers to save, load and clear letter drafts
- load stored draft on letter creation screen and keep it in sync with user inputs
- remove draft once letter generation succeeds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: fetch failed in expo cli)*

------
https://chatgpt.com/codex/tasks/task_e_68ad942eaccc8320854e110f2937f92a