### PR TITLE
Add searchable favorites for letter types

### DIFF
--- a/utils/favoriteTypes.ts
+++ b/utils/favoriteTypes.ts
@@ -1,0 +1,22 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = 'favoriteLetterTypes';
+
+export async function loadFavoriteTypes(): Promise<string[]> {
+  try {
+    const json = await AsyncStorage.getItem(STORAGE_KEY);
+    return json ? JSON.parse(json) as string[] : [];
+  } catch (err) {
+    console.error('Failed to load favorite letter types', err);
+    return [];
+  }
+}
+
+export async function saveFavoriteTypes(favorites: string[]) {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(favorites));
+  } catch (err) {
+    console.error('Failed to save favorite letter types', err);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add AsyncStorage helpers for letter type favorites
- enable search bar to filter and favorite letter types

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: fetch failed while running expo lint)
- `npx tsc -p tsconfig.json --noEmit` (fails: Type errors in settings and DatePicker)


------
https://chatgpt.com/codex/tasks/task_e_68ad9409ee9c83209f9d6dfe5966bd72