### PR TITLE
feat: add accessibility labels to interactive components

### DIFF
--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -109,10 +109,14 @@ export default function HistoryScreen() {
 
   const renderLetter = (letter: any) => (
     <View key={letter.id} style={[styles.letterCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
-      <TouchableOpacity 
+      <TouchableOpacity
         style={styles.letterContent}
         onPress={() => handleLetterPress(letter.id)}
         activeOpacity={0.7}
+        accessible
+        accessibilityRole="button"
+        accessibilityLabel={`Ouvrir le courrier ${letter.title}`}
+        accessibilityHint="Affiche les détails du courrier"
       >
         <View style={[styles.letterIcon, { backgroundColor: colors.primary + '15' }]}>
           <FileText size={24} color={colors.primary} />
@@ -132,27 +136,43 @@ export default function HistoryScreen() {
       </TouchableOpacity>
       
       <View style={styles.actionButtons}>
-        <TouchableOpacity 
+        <TouchableOpacity
           style={[styles.actionButton, { backgroundColor: colors.accent + '15' }]}
           onPress={() => handleShare(letter)}
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Partager"
+          accessibilityHint="Partage le courrier"
         >
           <Share2 size={18} color={colors.accent} />
         </TouchableOpacity>
-        <TouchableOpacity 
+        <TouchableOpacity
           style={[styles.actionButton, { backgroundColor: colors.primary + '15' }]}
           onPress={() => handleDownload(letter)}
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Télécharger"
+          accessibilityHint="Télécharge le courrier en PDF"
         >
           <Download size={18} color={colors.primary} />
         </TouchableOpacity>
-        <TouchableOpacity 
+        <TouchableOpacity
           style={[styles.actionButton, { backgroundColor: colors.warning + '15' }]}
           onPress={() => handleEmail(letter)}
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Envoyer par email"
+          accessibilityHint="Ouvre le client mail"
         >
           <Mail size={18} color={colors.warning} />
         </TouchableOpacity>
-        <TouchableOpacity 
+        <TouchableOpacity
           style={[styles.actionButton, { backgroundColor: colors.error + '15' }]}
           onPress={() => handleDelete(letter)}
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Supprimer"
+          accessibilityHint="Supprime le courrier"
         >
           <Trash2 size={18} color={colors.error} />
         </TouchableOpacity>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -70,7 +70,7 @@ export default function HomeScreen() {
     title: string,
     value: string | number,
     IconComponent: React.ComponentType<any>,
-    gradient: string[]
+    gradient: [string, string, ...string[]]
   ) => (
     <View key={title} style={[styles.statCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
       <LinearGradient colors={gradient} style={styles.statGradient}>
@@ -89,6 +89,10 @@ export default function HomeScreen() {
       style={[styles.letterCard, { backgroundColor: colors.card, borderColor: colors.border }]}
       onPress={() => handleLetterTypePress(item.id)}
       activeOpacity={0.7}
+      accessible
+      accessibilityRole="button"
+      accessibilityLabel={`Créer ${item.title}`}
+      accessibilityHint={`Ouvre le formulaire pour ${item.description.toLowerCase()}`}
     >
       <View style={[styles.letterIconContainer, { backgroundColor: item.color + '15' }]}>
         <item.icon size={28} color={item.color} />

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -101,9 +101,11 @@ export default function ProfileScreen() {
           onChangeText={(text) => setEditedProfile(prev => ({ ...prev, [key]: text }))}
           placeholder={placeholder}
           placeholderTextColor={colors.textSecondary}
+          accessible
+          accessibilityLabel={label}
         />
       ) : (
-        <Text style={[styles.fieldValue, { color: colors.text }]}>
+        <Text style={[styles.fieldValue, { color: colors.text }]}> 
           {value || placeholder}
         </Text>
       )}
@@ -117,6 +119,10 @@ export default function ProfileScreen() {
         <TouchableOpacity
           style={[styles.editButton, { backgroundColor: isEditing ? colors.accent : colors.primary }]}
           onPress={isEditing ? handleSave : () => setIsEditing(true)}
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel={isEditing ? 'Enregistrer le profil' : 'Modifier le profil'}
+          accessibilityHint={isEditing ? 'Sauvegarde les modifications du profil' : 'Permet de modifier les informations du profil'}
         >
           {isEditing ? (
             <>
@@ -141,9 +147,13 @@ export default function ProfileScreen() {
               <User size={32} color="#ffffff" />
             )}
           </View>
-          <TouchableOpacity 
+          <TouchableOpacity
             style={[styles.cameraButton, { backgroundColor: colors.accent }]}
             onPress={pickImage}
+            accessible
+            accessibilityRole="button"
+            accessibilityLabel="Changer la photo de profil"
+            accessibilityHint="Ouvre la galerie pour sélectionner une photo"
           >
             <Camera size={16} color="#ffffff" />
           </TouchableOpacity>
@@ -183,6 +193,8 @@ export default function ProfileScreen() {
                 placeholderTextColor={colors.textSecondary}
                 keyboardType="numeric"
                 maxLength={5}
+                accessible
+                accessibilityLabel="Code postal"
               />
             ) : (
               <Text style={[styles.fieldValue, { color: colors.text }]}>
@@ -222,12 +234,18 @@ export default function ProfileScreen() {
                 <TouchableOpacity
                   style={[styles.cancelButton, { backgroundColor: colors.surface, borderColor: colors.border }]}
                   onPress={handleSignatureRemove}
+                  accessible
+                  accessibilityRole="button"
+                  accessibilityLabel="Supprimer la signature"
                 >
                   <Text style={[styles.cancelButtonText, { color: colors.textSecondary }]}>Supprimer</Text>
                 </TouchableOpacity>
                 <TouchableOpacity
                   style={[styles.saveButton, { backgroundColor: colors.accent }]}
                   onPress={() => setShowSignaturePad(true)}
+                  accessible
+                  accessibilityRole="button"
+                  accessibilityLabel="Modifier la signature"
                 >
                   <Text style={styles.saveButtonText}>Modifier</Text>
                 </TouchableOpacity>
@@ -237,6 +255,9 @@ export default function ProfileScreen() {
             <TouchableOpacity
               style={[styles.saveButton, { backgroundColor: colors.accent }]}
               onPress={() => setShowSignaturePad(true)}
+              accessible
+              accessibilityRole="button"
+              accessibilityLabel="Ajouter une signature"
             >
               <Text style={styles.saveButtonText}>Ajouter une signature</Text>
             </TouchableOpacity>
@@ -248,12 +269,18 @@ export default function ProfileScreen() {
             <TouchableOpacity
               style={[styles.cancelButton, { backgroundColor: colors.surface, borderColor: colors.border }]}
               onPress={handleCancel}
+              accessible
+              accessibilityRole="button"
+              accessibilityLabel="Annuler les modifications"
             >
               <Text style={[styles.cancelButtonText, { color: colors.textSecondary }]}>Annuler</Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.saveButton, { backgroundColor: colors.accent }]}
               onPress={handleSave}
+              accessible
+              accessibilityRole="button"
+              accessibilityLabel="Enregistrer les modifications"
             >
               <Text style={styles.saveButtonText}>Enregistrer</Text>
             </TouchableOpacity>
@@ -273,6 +300,9 @@ export default function ProfileScreen() {
           <TouchableOpacity
             style={{ position: 'absolute', top: 40, right: 20 }}
             onPress={() => setShowSignaturePad(false)}
+            accessible
+            accessibilityRole="button"
+            accessibilityLabel="Fermer"
           >
             <Text style={{ color: '#000000' }}>Fermer</Text>
           </TouchableOpacity>

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -43,7 +43,7 @@ export default function SettingsScreen() {
   };
 
   const handleLegalPage = (slug: string) => {
-    router.push(`/legal/${slug}`);
+    router.push(`/legal/${slug}` as any);
   };
 
   const APP_URL =
@@ -100,6 +100,10 @@ export default function SettingsScreen() {
       style={[styles.settingItem, { backgroundColor: colors.card, borderColor: colors.border }]}
       onPress={onPress}
       activeOpacity={0.7}
+      accessible
+      accessibilityRole="button"
+      accessibilityLabel={title}
+      accessibilityHint={subtitle}
     >
       <View style={[styles.settingIcon, { backgroundColor: colors.primary + '15' }]}>
         {React.createElement(icon, { size: 20, color: colors.primary })}
@@ -117,7 +121,7 @@ export default function SettingsScreen() {
       key={option.key}
       style={[
         styles.themeOption,
-        { 
+        {
           backgroundColor: colors.card,
           borderColor: theme === option.key ? colors.primary : colors.border,
           borderWidth: theme === option.key ? 2 : 1,
@@ -125,6 +129,10 @@ export default function SettingsScreen() {
       ]}
       onPress={() => handleThemeChange(option.key as any)}
       activeOpacity={0.7}
+      accessible
+      accessibilityRole="button"
+      accessibilityLabel={`Thème ${option.label}`}
+      accessibilityHint="Change le thème de l'application"
     >
       <View style={[styles.themeIcon, { backgroundColor: colors.primary + '15' }]}>
         <option.icon size={20} color={colors.primary} />

--- a/app/create-letter.tsx
+++ b/app/create-letter.tsx
@@ -314,6 +314,9 @@ export default function CreateLetterScreen() {
           multiline={isMultiline}
           numberOfLines={isMultiline ? 4 : 1}
           keyboardType={field.type === 'number' ? 'numeric' : 'default'}
+          accessible
+          accessibilityLabel={field.label}
+          accessibilityHint={field.required ? 'Champ obligatoire' : undefined}
         />
       </View>
     );
@@ -333,6 +336,8 @@ export default function CreateLetterScreen() {
         placeholderTextColor={colors.textSecondary}
         keyboardType={key === 'postalCode' ? 'numeric' : 'default'}
         maxLength={key === 'postalCode' ? 5 : undefined}
+        accessible
+        accessibilityLabel={label}
       />
     </View>
   );
@@ -340,9 +345,13 @@ export default function CreateLetterScreen() {
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={styles.header}>
-        <TouchableOpacity 
+        <TouchableOpacity
           style={[styles.backButton, { backgroundColor: colors.surface }]}
           onPress={() => router.back()}
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Retour"
+          accessibilityHint="Revenir à l'écran précédent"
         >
           <ArrowLeft size={24} color={colors.text} />
         </TouchableOpacity>
@@ -402,6 +411,12 @@ export default function CreateLetterScreen() {
           ]}
           onPress={handleGenerateLetter}
           disabled={isGenerating}
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel={
+            isGenerating ? 'Génération du courrier en cours' : 'Générer le courrier'
+          }
+          accessibilityHint="Envoie les informations pour créer le courrier"
         >
           {isGenerating ? (
             <Loader size={24} color="#ffffff" />

--- a/app/letter-preview.tsx
+++ b/app/letter-preview.tsx
@@ -163,6 +163,10 @@ export default function LetterPreviewScreen() {
         <TouchableOpacity
           style={[styles.backButton, { backgroundColor: colors.surface }]}
           onPress={() => router.back()}
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Retour"
+          accessibilityHint="Revenir à l'écran précédent"
         >
           <ArrowLeft size={24} color={colors.text} />
         </TouchableOpacity>
@@ -181,28 +185,31 @@ export default function LetterPreviewScreen() {
         >
           {/* Body */}
           <View style={styles.letterBody}>
-            {isEditing ? (
-              <TextInput
-                style={[
-                  styles.editInput,
-                  { 
-                    color: colors.text, 
-                    borderColor: colors.border,
-                    backgroundColor: colors.background
-                  }
-                ]}
-                value={editedContent}
-                onChangeText={setEditedContent}
-                multiline
-                textAlignVertical="top"
-                placeholder="Contenu de la lettre..."
-                placeholderTextColor={colors.textSecondary}
-              />
-            ) : (
-              <Text style={[styles.bodyText, { color: colors.text }]}> 
-                {letter.content}
-              </Text>
-            )}
+              {isEditing ? (
+                <TextInput
+                  style={[
+                    styles.editInput,
+                    {
+                      color: colors.text,
+                      borderColor: colors.border,
+                      backgroundColor: colors.background
+                    }
+                  ]}
+                  value={editedContent}
+                  onChangeText={setEditedContent}
+                  multiline
+                  textAlignVertical="top"
+                  placeholder="Contenu de la lettre..."
+                  placeholderTextColor={colors.textSecondary}
+                  accessible
+                  accessibilityLabel="Contenu du courrier"
+                  accessibilityHint="Modifiez le texte du courrier"
+                />
+              ) : (
+                <Text style={[styles.bodyText, { color: colors.text }]}>
+                  {letter.content}
+                </Text>
+              )}
             {profile.signature ? (
               <Image
                 source={{ uri: profile.signature }}
@@ -227,10 +234,14 @@ export default function LetterPreviewScreen() {
         {/* Bouton Modifier/Sauvegarder */}
         <TouchableOpacity
           style={[
-            styles.actionButton, 
+            styles.actionButton,
             { backgroundColor: isEditing ? colors.primary : colors.accent }
           ]}
           onPress={isEditing ? handleSave : handleEdit}
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel={isEditing ? 'Enregistrer' : 'Modifier'}
+          accessibilityHint={isEditing ? 'Sauvegarde le courrier' : 'Passe en mode édition'}
         >
           {isEditing ? <Save size={20} color="#fff" /> : <Edit size={20} color="#fff" />}
         </TouchableOpacity>
@@ -240,6 +251,10 @@ export default function LetterPreviewScreen() {
           <TouchableOpacity
             style={[styles.actionButton, { backgroundColor: colors.error }]}
             onPress={handleCancel}
+            accessible
+            accessibilityRole="button"
+            accessibilityLabel="Annuler"
+            accessibilityHint="Annule les modifications"
           >
             <X size={20} color="#fff" />
           </TouchableOpacity>
@@ -251,24 +266,40 @@ export default function LetterPreviewScreen() {
             <TouchableOpacity
               style={[styles.actionButton, { backgroundColor: colors.accent }]}
               onPress={handleShare}
+              accessible
+              accessibilityRole="button"
+              accessibilityLabel="Partager"
+              accessibilityHint="Partage le courrier"
             >
               <Share2 size={20} color="#fff" />
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.actionButton, { backgroundColor: colors.primary }]}
               onPress={handleDownload}
+              accessible
+              accessibilityRole="button"
+              accessibilityLabel="Télécharger"
+              accessibilityHint="Télécharge le courrier en PDF"
             >
               <Download size={20} color="#fff" />
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.actionButton, { backgroundColor: colors.warning }]}
               onPress={handleEmail}
+              accessible
+              accessibilityRole="button"
+              accessibilityLabel="Envoyer par email"
+              accessibilityHint="Ouvre le client mail"
             >
               <Mail size={20} color="#fff" />
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.actionButton, { backgroundColor: colors.secondary }]}
               onPress={handlePrint}
+              accessible
+              accessibilityRole="button"
+              accessibilityLabel="Imprimer"
+              accessibilityHint="Lance l'impression du courrier"
             >
               <Printer size={20} color="#fff" />
             </TouchableOpacity>

--- a/components/CitySelector.tsx
+++ b/components/CitySelector.tsx
@@ -73,6 +73,9 @@ export default function CitySelector({
     <TouchableOpacity
       style={[styles.cityItem, { borderBottomColor: colors.border }]}
       onPress={() => handleCitySelect(item)}
+      accessible
+      accessibilityRole="button"
+      accessibilityLabel={`Choisir ${item}`}
     >
       <Text style={[styles.cityText, { color: colors.text }]}>{item}</Text>
     </TouchableOpacity>
@@ -84,7 +87,7 @@ export default function CitySelector({
       <TouchableOpacity
         style={[
           styles.selector,
-          { 
+          {
             borderColor: colors.border,
             backgroundColor: cities.length > 0 ? colors.surface : colors.background,
             opacity: cities.length > 0 ? 1 : 0.5
@@ -92,6 +95,20 @@ export default function CitySelector({
         ]}
         onPress={openModal}
         disabled={cities.length === 0}
+        accessible
+        accessibilityRole="button"
+        accessibilityLabel={
+          selectedCity
+            ? `Ville sélectionnée ${selectedCity}. Appuyez pour changer`
+            : cities.length > 0
+              ? 'Sélectionner une ville'
+              : "Saisir d'abord le code postal"
+        }
+        accessibilityHint={
+          cities.length > 0
+            ? 'Ouvre la liste des villes disponibles'
+            : undefined
+        }
       >
         <MapPin size={20} color={colors.textSecondary} />
         <Text style={[
@@ -116,6 +133,9 @@ export default function CitySelector({
               <TouchableOpacity
                 style={[styles.closeButton, { backgroundColor: colors.surface }]}
                 onPress={() => setIsModalVisible(false)}
+                accessible
+                accessibilityRole="button"
+                accessibilityLabel="Fermer la sélection de ville"
               >
                 <Text style={[styles.closeButtonText, { color: colors.text }]}>✕</Text>
               </TouchableOpacity>
@@ -127,6 +147,9 @@ export default function CitySelector({
               placeholderTextColor={colors.textSecondary}
               value={searchText}
               onChangeText={setSearchText}
+              accessible
+              accessibilityLabel="Rechercher une ville"
+              accessibilityHint="Saisir le nom de la ville"
             />
 
             <FlatList

--- a/components/DatePicker.tsx
+++ b/components/DatePicker.tsx
@@ -52,6 +52,14 @@ export default function DatePicker({ value, onDateChange, placeholder = 'Sélect
       <TouchableOpacity
         style={[styles.dateButton, { borderColor: colors.border, backgroundColor: colors.surface }]}
         onPress={showDatePicker}
+        accessible
+        accessibilityRole="button"
+        accessibilityLabel={
+          value
+            ? `Changer la date${label ? ` ${label}` : ''}`
+            : `Sélectionner${label ? ` ${label}` : ' une date'}`
+        }
+        accessibilityHint="Ouvre le sélecteur de date"
       >
         <Calendar size={20} color={colors.textSecondary} />
         <Text style={[styles.dateText, { color: value ? colors.text : colors.textSecondary }]}>
@@ -68,7 +76,6 @@ export default function DatePicker({ value, onDateChange, placeholder = 'Sélect
         locale="fr_FR"
         confirmTextIOS="Confirmer"
         cancelTextIOS="Annuler"
-        headerTextIOS="Choisir une date"
       />
     </View>
   );

--- a/components/LegalPage.tsx
+++ b/components/LegalPage.tsx
@@ -19,6 +19,10 @@ export default function LegalPage({ title, children }: LegalPageProps) {
         <TouchableOpacity
           onPress={() => router.back()}
           style={[styles.backButton, { backgroundColor: colors.surface }]}
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Retour"
+          accessibilityHint="Revenir à l'écran précédent"
         >
           <ArrowLeft size={24} color={colors.text} />
         </TouchableOpacity>


### PR DESCRIPTION
## Summary
- add accessibility labels/hints to letter type, history, profile and settings buttons
- improve accessibility for form inputs, city selector and date picker
- ensure preview and create letter screens expose screen reader friendly controls

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad941767c88320b8947f00e6f72f36