### PR TITLE
Add monthly generation limit for free plan

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -8,6 +8,7 @@ import {
   TouchableOpacity,
   Image,
   TextInput,
+  Alert,
 } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useLetters } from '@/contexts/LetterContext';
@@ -59,7 +60,7 @@ const letterTypes = [
 
 export default function HomeScreen() {
   const { colors } = useTheme();
-  const { getStatistics } = useLetters();
+  const { getStatistics, canGenerateLetter } = useLetters();
   const { profile } = useUser();
   const router = useRouter();
   const stats = getStatistics();
@@ -75,6 +76,13 @@ export default function HomeScreen() {
   }, []);
 
   const handleLetterTypePress = (type: string) => {
+    if (!canGenerateLetter('free')) {
+      Alert.alert(
+        'Limite atteinte',
+        'Vous avez atteint la limite de 10 courriers pour le plan gratuit. Passez au plan premium pour continuer.'
+      );
+      return;
+    }
     router.push({ pathname: '/create-letter', params: { type } });
   };
 

--- a/app/create-letter.tsx
+++ b/app/create-letter.tsx
@@ -114,7 +114,7 @@ const letterTypeFields: Record<string, FormField[]> = {
 export default function CreateLetterScreen() {
   const { type } = useLocalSearchParams<{ type: string }>();
   const { colors } = useTheme();
-  const { addLetter } = useLetters();
+  const { addLetter, canGenerateLetter } = useLetters();
   const { profile } = useUser();
   const { recipients } = useRecipients();
   const router = useRouter();
@@ -203,6 +203,14 @@ export default function CreateLetterScreen() {
 
   const handleGenerateLetter = async () => {
     if (!validateForm()) return;
+
+    if (!canGenerateLetter('free')) {
+      Alert.alert(
+        'Limite atteinte',
+        'Vous avez atteint la limite de 10 courriers pour le plan gratuit. Passez au plan premium pour continuer.'
+      );
+      return;
+    }
 
     setIsGenerating(true);
     setGenerationError(null);

--- a/contexts/LetterContext.tsx
+++ b/contexts/LetterContext.tsx
@@ -17,6 +17,8 @@ interface LetterContextType {
   addLetter: (letter: Letter) => void;
   updateLetter: (id: string, updatedLetter: Letter) => void;
   deleteLetter: (id: string) => void;
+  getMonthlyCount: () => number;
+  canGenerateLetter: (plan: 'free' | 'premium') => boolean;
   getStatistics: () => {
     totalLetters: number;
     thisMonth: number;
@@ -60,11 +62,29 @@ export function LetterProvider({ children }: { children: React.ReactNode }) {
     });
   };
 
+  const getMonthlyCount = () => {
+    const now = new Date();
+    return letters.filter(letter => {
+      const letterDate = new Date(letter.createdAt);
+      return (
+        letterDate.getMonth() === now.getMonth() &&
+        letterDate.getFullYear() === now.getFullYear()
+      );
+    }).length;
+  };
+
+  const canGenerateLetter = (plan: 'free' | 'premium') => {
+    if (plan === 'free' && getMonthlyCount() >= 10) {
+      return false;
+    }
+    return true;
+  };
+
   const getStatistics = () => {
     const now = new Date();
     const thisMonth = letters.filter(letter => {
       const letterDate = new Date(letter.createdAt);
-      return letterDate.getMonth() === now.getMonth() && 
+      return letterDate.getMonth() === now.getMonth() &&
              letterDate.getFullYear() === now.getFullYear();
     }).length;
 
@@ -86,7 +106,7 @@ export function LetterProvider({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <LetterContext.Provider value={{ letters, addLetter, updateLetter, deleteLetter, getStatistics }}>
+    <LetterContext.Provider value={{ letters, addLetter, updateLetter, deleteLetter, getMonthlyCount, canGenerateLetter, getStatistics }}>
       {children}
     </LetterContext.Provider>
   );


### PR DESCRIPTION
## Summary
- track letters generated this month
- restrict free users to 10 letters per month
- warn users when generation limit reached

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: fetch failed)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Type 'string[]' is not assignable to type 'readonly [ColorValue, ColorValue, ...]')*

------
https://chatgpt.com/codex/tasks/task_e_68c4468a25f48320a5d6073d9d4faf2e