### PR TITLE
feat: add subscription management with premium plan

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -12,6 +12,7 @@ import {
 import { useTheme } from '@/contexts/ThemeContext';
 import { useLetters } from '@/contexts/LetterContext';
 import { useUser } from '@/contexts/UserContext';
+import { useSubscription } from '@/contexts/SubscriptionContext';
 import { useRouter } from 'expo-router';
 import {
   FileText,
@@ -61,6 +62,7 @@ export default function HomeScreen() {
   const { colors } = useTheme();
   const { getStatistics } = useLetters();
   const { profile } = useUser();
+  const { plan } = useSubscription();
   const router = useRouter();
   const stats = getStatistics();
 
@@ -176,9 +178,25 @@ export default function HomeScreen() {
       </View>
 
       {/* Slogan */}
-      <Text style={[styles.tagline, { color: colors.textSecondary }]}>
+      <Text style={[styles.tagline, { color: colors.textSecondary }]}> 
         Votre courrier, prêt en un instant
       </Text>
+
+      {/* Plan */}
+      <View style={[styles.planBanner, { backgroundColor: colors.card, borderColor: colors.border }]}>
+        <Text style={[styles.planText, { color: colors.text }]}>Plan actuel : {plan === 'premium' ? 'Premium' : 'Gratuit'}</Text>
+        {plan === 'free' && (
+          <TouchableOpacity
+            style={[styles.planButton, { backgroundColor: colors.primary }]}
+            onPress={() => router.push('/subscribe')}
+            accessible
+            accessibilityRole="button"
+            accessibilityLabel="Passer au Premium"
+          >
+            <Text style={styles.planButtonText}>Passer au Premium</Text>
+          </TouchableOpacity>
+        )}
+      </View>
 
       {/* Statistiques */}
       <View style={styles.statsContainer}>
@@ -239,6 +257,10 @@ const styles = StyleSheet.create({
   logo:        { width: 48, height: 48, borderRadius: 24, justifyContent: 'center', alignItems: 'center', overflow: 'hidden' },
   profileImage:{ width: '100%', height: '100%', borderRadius: 24 },
   tagline:     { fontSize: 16, fontFamily: 'Inter-Medium', textAlign: 'center', marginBottom: 30, fontStyle: 'italic' },
+  planBanner: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 16, borderRadius: 12, borderWidth: 1, marginHorizontal: 20, marginBottom: 30 },
+  planText:   { fontSize: 16, fontFamily: 'Inter-Medium' },
+  planButton: { paddingVertical: 8, paddingHorizontal: 12, borderRadius: 8 },
+  planButtonText: { fontSize: 14, fontFamily: 'Inter-SemiBold', color: '#ffffff' },
   statsContainer: { flexDirection: 'row', flexWrap: 'wrap', paddingHorizontal: 20, gap: 12, marginBottom: 30 },
   statCard:    { flex: 1, minWidth: '47%', flexDirection: 'row', alignItems: 'center', padding: 16, borderRadius: 12, borderWidth: 1 },
   statGradient:{ width: 40, height: 40, borderRadius: 20, justifyContent: 'center', alignItems: 'center', marginRight: 12 },

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, TextInput, Alert, Image, Modal } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useUser } from '@/contexts/UserContext';
+import { useSubscription } from '@/contexts/SubscriptionContext';
+import { useRouter } from 'expo-router';
 import { User, Pencil, Save, Camera, Mail, Phone, MapPin, Building } from 'lucide-react-native';
 import * as ImagePicker from 'expo-image-picker';
 import CitySelector from '@/components/CitySelector';
@@ -11,6 +13,8 @@ import SignatureCanvas from 'react-native-signature-canvas';
 export default function ProfileScreen() {
   const { colors } = useTheme();
   const { profile, updateProfile } = useUser();
+  const { plan } = useSubscription();
+  const router = useRouter();
   const [isEditing, setIsEditing] = useState(false);
   const [editedProfile, setEditedProfile] = useState(profile);
   const [showSignaturePad, setShowSignaturePad] = useState(false);
@@ -138,12 +142,27 @@ export default function ProfileScreen() {
         </TouchableOpacity>
       </View>
 
-      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
-        <View style={[styles.avatarContainer, { backgroundColor: colors.card, borderColor: colors.border }]}>
-          <View style={[styles.avatar, { backgroundColor: colors.primary }]}>
-            {editedProfile.photo ? (
-              <Image source={{ uri: editedProfile.photo }} style={styles.avatarImage} />
-            ) : (
+        <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+          <View style={[styles.planContainer, { backgroundColor: colors.card, borderColor: colors.border }]}>
+            <Text style={[styles.planText, { color: colors.text }]}>Plan actuel : {plan === 'premium' ? 'Premium' : 'Gratuit'}</Text>
+            {plan === 'free' && (
+              <TouchableOpacity
+                style={[styles.upgradeButton, { backgroundColor: colors.primary }]}
+                onPress={() => router.push('/subscribe')}
+                accessible
+                accessibilityRole="button"
+                accessibilityLabel="Passer au Premium"
+              >
+                <Text style={styles.upgradeButtonText}>Passer au Premium</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+
+          <View style={[styles.avatarContainer, { backgroundColor: colors.card, borderColor: colors.border }]}>
+            <View style={[styles.avatar, { backgroundColor: colors.primary }]}>
+              {editedProfile.photo ? (
+                <Image source={{ uri: editedProfile.photo }} style={styles.avatarImage} />
+              ) : (
               <User size={32} color="#ffffff" />
             )}
           </View>
@@ -347,6 +366,29 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     paddingHorizontal: 20,
+  },
+  planContainer: {
+    padding: 20,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 16,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  planText: {
+    fontSize: 16,
+    fontFamily: 'Inter-Medium',
+  },
+  upgradeButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+  },
+  upgradeButtonText: {
+    color: '#ffffff',
+    fontSize: 14,
+    fontFamily: 'Inter-SemiBold',
   },
   avatarContainer: {
     alignSelf: 'center',

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from '@/contexts/ThemeContext';
 import { UserProvider } from '@/contexts/UserContext';
 import { LetterProvider } from '@/contexts/LetterContext';
 import { RecipientProvider } from '@/contexts/RecipientContext';
+import { SubscriptionProvider } from '@/contexts/SubscriptionContext';
 import { useFonts } from 'expo-font';
 import {
   Inter_400Regular,
@@ -39,19 +40,22 @@ export default function RootLayout() {
 
   return (
     <ThemeProvider>
-      <UserProvider>
-        <RecipientProvider>
-          <LetterProvider>
-            <Stack screenOptions={{ headerShown: false }}>
-              <Stack.Screen name="(tabs)" />
-              <Stack.Screen name="create-letter" />
-              <Stack.Screen name="letter-preview" />
-              <Stack.Screen name="+not-found" />
-            </Stack>
-            <StatusBar style="auto" />
-          </LetterProvider>
-        </RecipientProvider>
-      </UserProvider>
+      <SubscriptionProvider>
+        <UserProvider>
+          <RecipientProvider>
+            <LetterProvider>
+              <Stack screenOptions={{ headerShown: false }}>
+                <Stack.Screen name="(tabs)" />
+                <Stack.Screen name="create-letter" />
+                <Stack.Screen name="letter-preview" />
+                <Stack.Screen name="subscribe" />
+                <Stack.Screen name="+not-found" />
+              </Stack>
+              <StatusBar style="auto" />
+            </LetterProvider>
+          </RecipientProvider>
+        </UserProvider>
+      </SubscriptionProvider>
     </ThemeProvider>
   );
 }

--- a/app/create-letter.tsx
+++ b/app/create-letter.tsx
@@ -114,7 +114,7 @@ const letterTypeFields: Record<string, FormField[]> = {
 export default function CreateLetterScreen() {
   const { type } = useLocalSearchParams<{ type: string }>();
   const { colors } = useTheme();
-  const { addLetter } = useLetters();
+  const { addLetter, canGenerateLetter } = useLetters();
   const { profile } = useUser();
   const { recipients } = useRecipients();
   const router = useRouter();
@@ -203,6 +203,13 @@ export default function CreateLetterScreen() {
 
   const handleGenerateLetter = async () => {
     if (!validateForm()) return;
+    if (!canGenerateLetter()) {
+      Alert.alert(
+        'Limite atteinte',
+        'Vous avez atteint la limite de 10 courriers ce mois-ci. Passez au plan Premium pour un accès illimité.'
+      );
+      return;
+    }
 
     setIsGenerating(true);
     setGenerationError(null);

--- a/app/subscribe.tsx
+++ b/app/subscribe.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useSubscription } from '@/contexts/SubscriptionContext';
+import { useRouter } from 'expo-router';
+
+export default function SubscribeScreen() {
+  const { colors } = useTheme();
+  const { plan, upgrade, downgrade } = useSubscription();
+  const router = useRouter();
+
+  const handleUpgrade = () => {
+    upgrade();
+    router.back();
+  };
+
+  return (
+    <ScrollView
+      style={{ flex: 1, backgroundColor: colors.background }}
+      contentContainerStyle={styles.container}
+    >
+      <Text style={[styles.title, { color: colors.text }]}>Choisissez votre offre</Text>
+
+      <View style={[styles.planCard, { borderColor: colors.border, backgroundColor: colors.card }]}>
+        <Text style={[styles.planName, { color: colors.text }]}>Gratuit</Text>
+        <Text style={[styles.planDetails, { color: colors.textSecondary }]}>10 lettres/mois</Text>
+        {plan === 'free' && (
+          <Text style={[styles.currentTag, { color: colors.primary }]}>Plan actuel</Text>
+        )}
+      </View>
+
+      <View style={[styles.planCard, { borderColor: colors.border, backgroundColor: colors.card }]}>
+        <Text style={[styles.planName, { color: colors.text }]}>Premium</Text>
+        <Text style={[styles.planDetails, { color: colors.textSecondary }]}>Illimité pour ~4,99 € / mois</Text>
+        {plan === 'premium' ? (
+          <TouchableOpacity
+            style={[styles.downgradeButton, { backgroundColor: colors.warning }]}
+            onPress={downgrade}
+            accessible
+            accessibilityRole="button"
+            accessibilityLabel="Revenir au plan gratuit"
+          >
+            <Text style={styles.buttonText}>Revenir au Gratuit</Text>
+          </TouchableOpacity>
+        ) : (
+          <TouchableOpacity
+            style={[styles.upgradeButton, { backgroundColor: colors.primary }]}
+            onPress={handleUpgrade}
+            accessible
+            accessibilityRole="button"
+            accessibilityLabel="Passer au Premium"
+          >
+            <Text style={styles.buttonText}>Passer au Premium</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 20, alignItems: 'center' },
+  title: { fontSize: 24, fontFamily: 'Inter-Bold', marginBottom: 20 },
+  planCard: { width: '100%', padding: 20, borderWidth: 1, borderRadius: 12, marginBottom: 16, alignItems: 'center' },
+  planName: { fontSize: 20, fontFamily: 'Inter-SemiBold', marginBottom: 8 },
+  planDetails: { fontSize: 16, fontFamily: 'Inter-Regular', marginBottom: 12, textAlign: 'center' },
+  upgradeButton: { paddingVertical: 12, paddingHorizontal: 24, borderRadius: 8 },
+  downgradeButton: { paddingVertical: 12, paddingHorizontal: 24, borderRadius: 8 },
+  buttonText: { color: '#fff', fontSize: 16, fontFamily: 'Inter-SemiBold' },
+  currentTag: { marginTop: 8, fontSize: 14, fontFamily: 'Inter-Medium' },
+});
+

--- a/contexts/SubscriptionContext.tsx
+++ b/contexts/SubscriptionContext.tsx
@@ -1,0 +1,62 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export type Plan = 'free' | 'premium';
+
+interface SubscriptionContextType {
+  plan: Plan;
+  upgrade: () => void;
+  downgrade: () => void;
+}
+
+const SubscriptionContext = createContext<SubscriptionContextType | undefined>(undefined);
+
+export function SubscriptionProvider({ children }: { children: React.ReactNode }) {
+  const [plan, setPlan] = useState<Plan>('free');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem('subscriptionPlan');
+        if (stored === 'premium' || stored === 'free') {
+          setPlan(stored);
+        }
+      } catch (e) {
+        console.error('Failed to load subscription plan', e);
+      }
+    })();
+  }, []);
+
+  const persistPlan = async (value: Plan) => {
+    try {
+      await AsyncStorage.setItem('subscriptionPlan', value);
+    } catch (e) {
+      console.error('Failed to save subscription plan', e);
+    }
+  };
+
+  const upgrade = () => {
+    setPlan('premium');
+    persistPlan('premium');
+  };
+
+  const downgrade = () => {
+    setPlan('free');
+    persistPlan('free');
+  };
+
+  return (
+    <SubscriptionContext.Provider value={{ plan, upgrade, downgrade }}>
+      {children}
+    </SubscriptionContext.Provider>
+  );
+}
+
+export function useSubscription() {
+  const context = useContext(SubscriptionContext);
+  if (!context) {
+    throw new Error('useSubscription must be used within a SubscriptionProvider');
+  }
+  return context;
+}
+


### PR DESCRIPTION
## Summary
- add subscription context persisting plan and upgrade/downgrade helpers
- create subscribe screen to present free and premium offers
- show current plan with upgrade CTA in profile and home tabs
- bypass quota check for premium users when generating letters

## Testing
- `npm run lint` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c446b73ee48320a897ae6c1dec44b6