### PR TITLE
Add help page and support service

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -7,24 +7,25 @@ import {
   TouchableOpacity,
   Alert,
   Share,
-  Linking,
-  Platform,
+  Linking
 } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useRouter } from 'expo-router';
-import { 
-  Moon, 
-  Sun, 
+import {
+  Moon,
+  Sun,
   Monitor,
-  Info, 
-  FileText, 
+  Info,
+  FileText,
   Shield,
   ChevronRight,
   Star,
   MessageCircle,
-  Share2
+  Share2,
+  HelpCircle
 } from 'lucide-react-native';
 import MyBanner from '@/components/MyBanner';
+import { contactSupport } from '@/services/support';
 
 export default function SettingsScreen() {
   const { colors, theme, setTheme } = useTheme();
@@ -68,21 +69,6 @@ export default function SettingsScreen() {
       });
     } catch {
       Alert.alert('Erreur', "Impossible de partager l'application");
-    }
-  };
-
-  const handleSupport = async () => {
-    const url =
-      'https://mail.google.com/mail/?view=cm&fs=1&to=webmaster@drcomputer60290.fr&su=Support%20Courrier-Expert';
-    try {
-      const supported = await Linking.canOpenURL(url);
-      if (supported) {
-        await Linking.openURL(url);
-      } else {
-        Alert.alert('Erreur', "Gmail n'est pas disponible");
-      }
-    } catch {
-      Alert.alert('Erreur', "Impossible d'ouvrir Gmail");
     }
   };
 
@@ -154,26 +140,33 @@ export default function SettingsScreen() {
 
         <View style={styles.section}>
           <Text style={[styles.sectionTitle, { color: colors.text }]}>Application</Text>
-          
+
           {renderSetting(
             'Noter l\'application',
             'Partagez votre expérience',
             Star,
             handleRateApp
           )}
-          
+
           {renderSetting(
             'Partager l\'application',
             'Recommander à vos contacts',
             Share2,
             handleShareApp
           )}
-          
+
+          {renderSetting(
+            'Aide',
+            'FAQ et tutoriels',
+            HelpCircle,
+            () => router.push('/help' as any)
+          )}
+
           {renderSetting(
             'Support',
             'Contactez notre équipe',
             MessageCircle,
-            handleSupport
+            contactSupport
           )}
         </View>
 

--- a/app/help.tsx
+++ b/app/help.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { ArrowLeft, Mail } from 'lucide-react-native';
+import { useRouter } from 'expo-router';
+import { useTheme } from '@/contexts/ThemeContext';
+import { contactSupport } from '@/services/support';
+
+export default function HelpScreen() {
+  const { colors } = useTheme();
+  const router = useRouter();
+
+  const faqs = [
+    {
+      q: "Comment créer un courrier ?",
+      a: "Utilisez le bouton 'Créer' et remplissez les informations requises.",
+    },
+    {
+      q: 'Puis-je modifier un courrier après génération ?',
+      a: "Oui, vous pouvez éditer le texte avant l'envoi ou l'impression.",
+    },
+  ];
+
+  const tutorials = [
+    {
+      title: 'Premiers pas',
+      description: "Découvrez les fonctionnalités essentielles de Courrier-Expert.",
+    },
+    {
+      title: 'Gérer vos destinataires',
+      description: "Ajoutez, modifiez ou supprimez des destinataires facilement.",
+    },
+  ];
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={styles.header}>
+        <TouchableOpacity
+          onPress={() => router.back()}
+          style={[styles.backButton, { backgroundColor: colors.surface }]}
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Retour"
+          accessibilityHint="Revenir à l'écran précédent"
+        >
+          <ArrowLeft size={24} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.title, { color: colors.text }]}>Aide</Text>
+      </View>
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>FAQ</Text>
+        {faqs.map((item, index) => (
+          <View
+            key={index}
+            style={[styles.card, { backgroundColor: colors.card, borderColor: colors.border }]}
+          >
+            <Text style={[styles.question, { color: colors.text }]}>{item.q}</Text>
+            <Text style={[styles.answer, { color: colors.textSecondary }]}>{item.a}</Text>
+          </View>
+        ))}
+
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Tutoriels</Text>
+        {tutorials.map((item, index) => (
+          <View
+            key={index}
+            style={[styles.card, { backgroundColor: colors.card, borderColor: colors.border }]}
+          >
+            <Text style={[styles.question, { color: colors.text }]}>{item.title}</Text>
+            <Text style={[styles.answer, { color: colors.textSecondary }]}>{item.description}</Text>
+          </View>
+        ))}
+
+        <TouchableOpacity
+          style={[styles.contactButton, { backgroundColor: colors.primary }]}
+          onPress={contactSupport}
+          activeOpacity={0.7}
+        >
+          <Mail color="#fff" size={20} />
+          <Text style={[styles.contactText, { color: '#fff' }]}>Contact support</Text>
+        </TouchableOpacity>
+
+        <View style={{ height: 80 }} />
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 50,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    marginBottom: 24,
+  },
+  backButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontFamily: 'Inter-Bold',
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontFamily: 'Inter-SemiBold',
+    marginBottom: 12,
+  },
+  card: {
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 8,
+  },
+  question: {
+    fontSize: 16,
+    fontFamily: 'Inter-SemiBold',
+    marginBottom: 4,
+  },
+  answer: {
+    fontSize: 14,
+    fontFamily: 'Inter-Regular',
+  },
+  contactButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+    borderRadius: 12,
+    marginTop: 24,
+  },
+  contactText: {
+    marginLeft: 8,
+    fontSize: 16,
+    fontFamily: 'Inter-SemiBold',
+  },
+});
+

--- a/services/support.ts
+++ b/services/support.ts
@@ -1,0 +1,17 @@
+import { Linking, Alert } from 'react-native';
+
+const SUPPORT_EMAIL = 'webmaster@drcomputer60290.fr';
+const MAILTO_URL = `mailto:${SUPPORT_EMAIL}?subject=Support%20Courrier-Expert`;
+
+export async function contactSupport() {
+  try {
+    const supported = await Linking.canOpenURL(MAILTO_URL);
+    if (supported) {
+      await Linking.openURL(MAILTO_URL);
+    } else {
+      Alert.alert('Erreur', "Impossible d'ouvrir le client mail");
+    }
+  } catch {
+    Alert.alert('Erreur', "Impossible d'ouvrir le client mail");
+  }
+}


### PR DESCRIPTION
## Summary
- add help screen with FAQ and tutorials
- add Support module for opening mail client
- link new Help screen in settings and use support service for contact

## Testing
- `npm run lint` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c447bd0e9483209bafaca44d3d4647