### PR TITLE
docs: document start script for Expo Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ Pour s'abonner, l'utilisateur sélectionne son plan dans l'application et confir
 2. Start the development server:
 
    ```bash
-   npm run dev
-   # or
-   expo start
+   # Expo Go
+   npm run start
+
+   # Custom dev client
+   npm run start -- --dev-client
    ```
 
    The app can then be opened in Expo Go or a simulator.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "expo lint",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "start": "expo start --dev-client"
+    "start": "expo start"
   },
   "dependencies": {
     "@expo-google-fonts/inter": "^0.2.3",


### PR DESCRIPTION
## Summary
- update `npm start` script to use Expo Go
- document `npm run start` for Expo Go and custom dev client

## Testing
- `npm run lint` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4510527f88320a590a9b944d164cd