### PR TITLE
chore: remove redundant index entry

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,0 @@
-import { registerRootComponent } from 'expo';
-
-import App from './App';
-
-// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
-// It also ensures that whether you load the app in Expo Go or in a native build,
-// the environment is set up appropriately
-registerRootComponent(App);


### PR DESCRIPTION
## Summary
- remove legacy index.js since expo-router/entry is the app entry point
- restore .expo config after running local tooling

## Testing
- `npm run lint` *(fails: TypeError: fetch failed)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68c451027df48320a54748634351929c