### PR TITLE
fix: remove newArchEnabled flag

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,7 +15,6 @@
     "privacy": "public",
     "platforms": ["ios", "android", "web"],
     "jsEngine": "hermes",
-    "newArchEnabled": false,
     "ios": {
       "supportsTablet": true
     },


### PR DESCRIPTION
## Summary
- remove `newArchEnabled` flag from expo config to match Expo Go behavior

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4558261348320b51e67f0174a9a5a