### PR TITLE
chore: remove expo router babel plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['expo-router/babel', 'react-native-reanimated/plugin'],
+    plugins: ['react-native-reanimated/plugin'],
   };
 };


### PR DESCRIPTION
## Summary
- remove `expo-router/babel` plugin from Babel config

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: TypeError: fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_68c45582faf48320891f467813f15d46