### PR TITLE
docs: clarify dev build requirement for ads and notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Pour s'abonner, l'utilisateur sélectionne son plan dans l'application et confir
 
    For production builds, set `BACKEND_URL` to the appropriate server URL in your deployment environment.
 
+### Limitations d’Expo Go
+
+Les modules `react-native-google-mobile-ads` et les notifications push via `expo-notifications` nécessitent une build de développement (`expo run:android` ou `expo run:ios`). Ces fonctionnalités ne sont pas prises en charge dans Expo Go.
+
+
 ### Using React Native DevTools
 
 To enable the React Native DevTools, add the following to `app.json` under the `expo` key and rebuild:


### PR DESCRIPTION
## Summary
- document that `react-native-google-mobile-ads` and push notifications from `expo-notifications` need a development build and are not supported in Expo Go

## Testing
- `npm run lint` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4558476c08320adbf613f6520ccb9