### PR TITLE
Guard AdMob init for Expo Go

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -2,7 +2,6 @@ import { Tabs, SplashScreen, usePathname, useRouter } from 'expo-router';
 import { Chrome as Home, History, User, Settings, Users } from 'lucide-react-native';
 import { useTheme } from '@/contexts/ThemeContext';
 import React, { useEffect } from 'react';
-import mobileAds from 'react-native-google-mobile-ads';
 import { Alert, Platform } from 'react-native';
 import { useUser } from '@/contexts/UserContext';
 
@@ -13,14 +12,17 @@ export default function TabLayout() {
 
   useEffect(() => {
     const initAdMob = async () => {
-      try {
-        if (Platform.OS === 'android' || Platform.OS === 'ios') {
+      if (Platform.OS === 'android' || Platform.OS === 'ios') {
+        try {
+          const { default: mobileAds } = await import('react-native-google-mobile-ads');
           await mobileAds().initialize();
           console.log('✅ AdMob initialized');
+        } catch (error) {
+          console.error('❌ AdMob initialization failed', error);
+        } finally {
+          SplashScreen.hideAsync();
         }
-      } catch (error) {
-        console.error('❌ AdMob initialization failed', error);
-      } finally {
+      } else {
         SplashScreen.hideAsync();
       }
     };


### PR DESCRIPTION
## Summary
- dynamically import the AdMob SDK inside the tab layout to avoid bundling issues on non-native platforms
- hide the splash screen when AdMob isn’t available so Expo Go and web can load the navigator

## Testing
- npm run lint *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd8624d34832093df702a0cd1fc8a