### PR TITLE
Guard Google Mobile Ads usage in Expo Go

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -4,15 +4,22 @@ import { useTheme } from '@/contexts/ThemeContext';
 import React, { useEffect } from 'react';
 import { Alert, Platform } from 'react-native';
 import { useUser } from '@/contexts/UserContext';
+import Constants from 'expo-constants';
 
 export default function TabLayout() {
   const router = useRouter();
   const pathname = usePathname();
   const { profile } = useUser();
+  const isExpoGo = Constants?.appOwnership === 'expo';
 
   useEffect(() => {
     const initAdMob = async () => {
       if (Platform.OS === 'android' || Platform.OS === 'ios') {
+        if (isExpoGo) {
+          await SplashScreen.hideAsync();
+          return;
+        }
+
         try {
           const { default: mobileAds } = await import('react-native-google-mobile-ads');
           await mobileAds().initialize();
@@ -20,15 +27,15 @@ export default function TabLayout() {
         } catch (error) {
           console.error('❌ AdMob initialization failed', error);
         } finally {
-          SplashScreen.hideAsync();
+          await SplashScreen.hideAsync();
         }
       } else {
-        SplashScreen.hideAsync();
+        await SplashScreen.hideAsync();
       }
     };
 
     initAdMob();
-  }, []);
+  }, [isExpoGo]);
 
   const isProfileComplete =
     profile.firstName.trim() &&

--- a/components/MyBanner.tsx
+++ b/components/MyBanner.tsx
@@ -1,21 +1,36 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import {
-  BannerAd,
-  BannerAdSize,
-  TestIds,
-} from 'react-native-google-mobile-ads';
+import Constants from 'expo-constants';
 
-// Pendant le dev, utilise l’ID de test
-const BANNER_AD_UNIT = __DEV__
-  ? TestIds.BANNER
-  : 'ca-app-pub-3734567410194819/3849723391'; // ton Ad Unit ID production
+type GoogleMobileAdsModule = typeof import('react-native-google-mobile-ads');
+
+const isExpoGo = Constants?.appOwnership === 'expo';
+
+let GoogleMobileAds: GoogleMobileAdsModule | null = null;
+
+if (!isExpoGo) {
+  try {
+    GoogleMobileAds = require('react-native-google-mobile-ads');
+  } catch (error) {
+    console.warn('react-native-google-mobile-ads module unavailable', error);
+  }
+}
 
 export default function MyBanner() {
+  if (!GoogleMobileAds) {
+    return null;
+  }
+
+  const { BannerAd, BannerAdSize, TestIds } = GoogleMobileAds;
+
+  const bannerAdUnit = __DEV__
+    ? TestIds.BANNER
+    : 'ca-app-pub-3734567410194819/3849723391'; // ton Ad Unit ID production
+
   return (
     <View style={styles.wrapper}>
       <BannerAd
-        unitId={BANNER_AD_UNIT}
+        unitId={bannerAdUnit}
         size={BannerAdSize.LARGE_BANNER}
         requestOptions={{
           requestNonPersonalizedAdsOnly: true,


### PR DESCRIPTION
## Summary
- guard the Google Mobile Ads banner component so it only loads when the native module is available and becomes a no-op in Expo Go
- detect Expo Go before initializing mobile ads in the tab layout while still hiding the splash screen when ads are skipped

## Testing
- npm run lint *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe23bf4d8832090e5e78df8af0234