### PR TITLE
chore: switch to worklets babel plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['react-native-reanimated/plugin'],
+    plugins: ['react-native-worklets/plugin'],
   };
 };


### PR DESCRIPTION
## Summary
- update the Babel config to use the react-native-worklets plugin instead of the reanimated plugin

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbe5e4277883208bbb75316ce05fb5